### PR TITLE
feat(memory): add SQLite persistence to LongTermStore

### DIFF
--- a/.ai/current.md
+++ b/.ai/current.md
@@ -1,0 +1,76 @@
+# Current Work
+
+This file defines what is being worked on right now, why, and how it fits into the larger project.
+Update this file every time focus shifts — before starting new work, not after.
+
+---
+
+## Project branch
+
+**Framework — `bdm-core`**
+
+BDM has two parallel branches of work:
+
+| Branch | Purpose |
+|---|---|
+| **Research** | Studying consciousness, documenting hypotheses, designing experiments |
+| **Framework** | Building the software tools that make those experiments possible |
+| **Probe** | Measurement layer — tests that compare BDM-augmented vs baseline systems |
+
+Current work is in **Framework**, building the foundation that Research and Probe depend on.
+
+---
+
+## Active milestone
+
+**M1 — Memory Core**
+
+The memory layer is the prerequisite for everything else. Without persistent memory that survives across sessions, the research questions about continuity, identity, and consciousness gaps cannot be tested at all. You cannot study whether a system "remembers who it talked to yesterday" if the system has no yesterday.
+
+---
+
+## Current focus
+
+**M1.4 — SQLite persistence for `LongTermStore`**
+
+Right now `LongTermStore` is backed by a plain Python dict. It works, but it is completely ephemeral — all stored events disappear when the process ends. This makes it useless for any cross-session research.
+
+The task is to replace the in-memory dict backend with SQLite so that `MemoryEvent` records survive across restarts.
+
+**Why this specifically:**
+- It is the smallest change that makes the memory layer actually useful for research
+- SQLite is stdlib — no new dependencies
+- The `MemoryStore` ABC means the swap is contained to `long_term.py` only
+- Everything above it (`ShortTermBuffer`, `EpisodicRecord`, future layers) stays unchanged
+
+---
+
+## How this serves the main research goal
+
+The main question BDM investigates is: *what is consciousness, and why can a computer not be a brain?*
+
+One of the hypotheses (H6) is that computational memory is structurally different from biological memory — not just in implementation, but in what it is for. To study that difference, you first need a working memory system you can observe and probe. Without SQLite persistence, every experiment resets. You cannot accumulate observations. You cannot build a "history" to study.
+
+SQLite persistence is not the research. It is what makes the research possible.
+
+---
+
+## What comes directly after
+
+Once SQLite is working:
+
+1. **`scoring.py`** (M1.7) — compute salience from recency and retrieval frequency
+2. **`examples/memory_demo.py`** — end-to-end demo of adding, persisting, and querying memories
+3. **`bdm.probe.continuity`** — first research probe: does the system know what happened in a prior session?
+
+The probe is where Framework connects back to Research. It is the first measurable test of a research hypothesis using real persisted data.
+
+---
+
+## What is explicitly out of scope right now
+
+- Reflection loop (M2) — depends on M1 being complete
+- Self-model extensions (M3) — depends on M2
+- LLM integration (M5) — depends on M1–M4
+- CLI (M6) — last
+- Any changes to documentation not directly related to current work

--- a/.ai/git-conventions.md
+++ b/.ai/git-conventions.md
@@ -1,0 +1,212 @@
+# Git Conventions
+
+Naming conventions for branches, issues, and pull requests in BDM.
+These apply to all contributors and to AI assistants working in this repository.
+
+---
+
+## Structure
+
+```
+GitHub Milestone  →  big goal, several weeks (M1, M2, M3...)
+GitHub Issue      →  one concrete task, 1-3 days
+Branch            →  one branch per issue
+PR                →  one PR per branch, references the issue
+```
+
+Module numbers (M1.1, M1.4...) exist only in `.ai/milestones.md` as internal tracking.
+They do not appear in branch names, issue titles, or PR titles.
+
+---
+
+## Branches
+
+### Format
+
+```
+<type>/<short-description>
+```
+
+### Types
+
+| Type | When to use |
+|---|---|
+| `feat/` | New functionality |
+| `fix/` | Bug fix |
+| `test/` | Tests only, no production code changes |
+| `docs/` | Documentation only |
+| `research/` | Hypotheses, experiment designs, research notes |
+| `probe/` | Measurement and evaluation layer |
+| `refactor/` | Internal restructure, no behavior change |
+| `chore/` | Tooling, CI, config, dependencies |
+
+### Examples
+
+```
+feat/sqlite-long-term-store
+feat/memory-text-search
+feat/memory-scoring
+feat/reflection-engine
+feat/self-model-goals
+fix/short-term-buffer-eviction-index
+test/episodic-record-coverage
+docs/manifesto-consciousness-framing
+research/h6-memory-reconstruction
+probe/continuity-cross-session
+probe/consistency-self-contradiction
+chore/ci-pytest-workflow
+```
+
+### Rules
+
+- All lowercase, words separated by hyphens
+- No slashes inside the description part
+- Describe the change, not the process
+- Never commit directly to `main`
+- One branch per issue, one PR per branch
+
+---
+
+## Issues
+
+### Format
+
+```
+[<tag>] Short description of what to build or fix
+```
+
+### Tags
+
+| Tag | When to use |
+|---|---|
+| `[feat]` | New functionality tied to a milestone |
+| `[bug]` | Something is broken |
+| `[test]` | Tests missing or broken |
+| `[research]` | Hypothesis, experiment design, reading |
+| `[probe]` | Measurement or evaluation task |
+| `[docs]` | Documentation task |
+| `[chore]` | Tooling, CI, config |
+| `[discussion]` | Open question, not yet a concrete task |
+
+### Examples
+
+```
+[feat] SQLite persistence for LongTermStore
+[feat] Text search in memory query
+[feat] Importance and confidence scoring
+[feat] Rule-based reflection engine
+[feat] Add ActiveGoal to SelfModelState
+[bug] ShortTermBuffer leaves stale entry in index after eviction
+[test] Add coverage for EpisodicRecord
+[test] Add coverage for ContinuityContext
+[research] Design experiment for H6 — memory reconstruction
+[research] Add hypothesis — embodiment as prerequisite for meaning
+[probe] Cross-session continuity probe
+[probe] Self-contradiction consistency probe
+[docs] Update roadmap with M1 completion
+[chore] Add pytest GitHub Actions workflow
+[discussion] SQLite FTS5 vs embedding search for text memory query
+```
+
+### GitHub Milestone assignment
+
+Every `[feat]`, `[bug]`, `[test]` issue must be assigned to a GitHub Milestone (M1, M2...).
+`[research]`, `[probe]`, `[docs]`, `[chore]`, `[discussion]` may be unassigned or assigned to the relevant milestone.
+
+### Labels
+
+| Label | Color | Description |
+|---|---|---|
+| `milestone:m1` | `#0052cc` | Milestone 1 — Memory Core |
+| `milestone:m2` | `#0052cc` | Milestone 2 — Reflection Loop |
+| `milestone:m3` | `#0052cc` | Milestone 3 — Self-Model |
+| `milestone:m4` | `#0052cc` | Milestone 4 — Continuity |
+| `milestone:m5` | `#0052cc` | Milestone 5 — LLM Integration |
+| `milestone:m6` | `#0052cc` | Milestone 6 — CLI |
+| `milestone:m7` | `#0052cc` | Milestone 7 — Experiments |
+| `type:feat` | `#0e8a16` | New feature |
+| `type:fix` | `#e11d48` | Bug fix |
+| `type:test` | `#7c3aed` | Tests only |
+| `type:docs` | `#f59e0b` | Documentation |
+| `type:research` | `#06b6d4` | Research |
+| `type:probe` | `#06b6d4` | Measurement / evaluation |
+| `type:chore` | `#6b7280` | Tooling, CI, config |
+| `branch:framework` | `#1d4ed8` | Work in packages/ |
+| `branch:research` | `#0891b2` | Work in research/ or docs/ |
+| `branch:probe` | `#0891b2` | Work in bdm.probe |
+| `status:blocked` | `#dc2626` | Cannot proceed — reason in issue |
+| `status:needs-discussion` | `#d97706` | Open question before work starts |
+
+---
+
+## Pull requests
+
+### Title format
+
+```
+<type>(<scope>): <short description> (#<issue-number>)
+```
+
+### Scope
+
+Use the milestone name or module name — short, lowercase:
+
+```
+feat(memory): add SQLite persistence to LongTermStore (#12)
+feat(memory): add text search to memory query (#15)
+fix(memory): remove stale index entry on buffer eviction (#8)
+test(memory): add coverage for EpisodicRecord (#14)
+feat(reflection): implement rule-based reflection engine (#20)
+docs(manifesto): reframe primary goal around consciousness research (#3)
+research(h6): add memory reconstruction experiment design (#19)
+probe(continuity): implement cross-session continuity probe (#21)
+chore(ci): add pytest GitHub Actions workflow (#5)
+```
+
+### Rules
+
+- Title must reference the issue number
+- One PR per issue — do not bundle unrelated changes
+- All tests must pass before requesting merge
+- Use `.github/PULL_REQUEST_TEMPLATE.md` for the description
+- Squash merge for `feat` and `fix` to keep `main` history clean
+- Merge commit acceptable for large `research` or `docs` PRs
+
+---
+
+## Commit messages
+
+```
+<type>(<scope>): <short description>
+
+feat, fix, test, docs, research, probe, chore, refactor
+scope = module or area name (memory, reflection, self_model, continuity, ci...)
+```
+
+Examples:
+```
+feat(memory): add SQLite backend to LongTermStore
+feat(memory): create table schema on first init
+test(memory): add persistence tests for LongTermStore
+fix(memory): remove stale index entry on buffer eviction
+```
+
+---
+
+## Branch lifecycle
+
+```
+main
+ └── feat/sqlite-long-term-store    ← branch from main
+      └── [commits]
+      └── PR → tests pass → squash merge to main
+      └── branch deleted after merge
+```
+
+- Branch from `main`
+- Work on the branch
+- Open PR when ready, reference the issue
+- Merge to `main` after review
+- Delete branch after merge
+
+No long-lived feature branches. No `develop` branch. `main` is always the working branch.

--- a/.ai/project.md
+++ b/.ai/project.md
@@ -6,11 +6,13 @@ Beautiful Deep Mind (BDM)
 
 ## One-line description
 
-An experimental cognitive architecture that explores how persistent memory, reflection, self-modeling, and context continuity can improve long-term coherence in AI-assisted systems.
+An experimental cognitive architecture and research framework for investigating what consciousness is and why current computational systems cannot be minds the way a human brain is.
 
 ## Primary goal
 
-> BDM is an experimental cognitive architecture for AI systems that investigates how memory, reflection, learning from experience, and context continuity may influence more consistent system behavior over time.
+> BDM investigates the question of consciousness and the gap between computation and cognition — by building software models of memory, reflection, self-modeling, and continuity, and studying where those models succeed, where they fail, and what those failures reveal.
+
+The framework (memory layers, reflection loop, self-model, continuity) is an instrument of investigation, not a product. The question is not "how do we build a better AI assistant." The question is: what is missing from a computer that a brain has — and is that gap an engineering problem or something more fundamental?
 
 BDM does not claim to create consciousness.
 BDM does not make medical claims.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,33 +1,46 @@
+## Closes
+
+Closes #
+
 ## Summary
 
-Describe what this pull request changes.
+What changed and why.
 
-## Reason
+## Type
 
-Why is this change useful for Beautiful Deep Mind?
+- [ ] `feat` — new functionality
+- [ ] `fix` — bug fix
+- [ ] `test` — tests only
+- [ ] `docs` — documentation only
+- [ ] `research` — hypothesis, experiment, or probe
+- [ ] `chore` — tooling, CI, config
 
-## Type of Contribution
+## Milestone / area
 
-- [ ] Documentation
-- [ ] Research note
-- [ ] Concept improvement
-- [ ] Architecture proposal
-- [ ] Experiment idea
-- [ ] Code
-- [ ] Other
+- [ ] M1 — Memory Core
+- [ ] M2 — Reflection Loop
+- [ ] M3 — Self-Model
+- [ ] M4 — Continuity
+- [ ] M5 — LLM Integration
+- [ ] M6 — CLI
+- [ ] M7 — Experiments
+- [ ] Research / Probe (not tied to a milestone)
+- [ ] Docs / Chore
+
+## Tests
+
+- [ ] `pytest` passes locally
+- [ ] New code has tests
+- [ ] No tests were deleted without justification
 
 ## Limitations
 
-Describe any assumptions, limitations, or open questions.
+Any known limitations, open questions, or follow-up issues.
 
-## Contribution Agreement
+## Contribution agreement
 
-By submitting this pull request, I confirm that:
-
-- [ ] I have read `LICENSE.md`.
-- [ ] I understand that Beautiful Deep Mind is source-available, not open source.
-- [ ] I agree that my contribution may be assigned or licensed to Boring Code under the terms described in `LICENSE.md`.
-- [ ] I have the right to submit this contribution.
-- [ ] This contribution does not include third-party copyrighted material without permission.
-- [ ] This contribution does not make medical claims.
-- [ ] This contribution does not claim that BDM creates, proves, uploads, transfers, or preserves consciousness.
+- [ ] I have read `LICENSE.md`
+- [ ] I understand this project is source-available, not open source
+- [ ] I agree my contribution may be assigned to Boring Code per `LICENSE.md`
+- [ ] This contribution makes no medical claims
+- [ ] This contribution makes no consciousness claims

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,14 @@ It defines how Claude should behave in this repository.
 
 ---
 
+## Read this first
+
+**Current work, active task, and why:** `.ai/current.md`
+
+Always read `.ai/current.md` before starting any task. It tells you what is being worked on right now, which branch of the project it belongs to, and what is explicitly out of scope. If the user asks you to do something not covered there, confirm before proceeding.
+
+---
+
 ## Project identity
 
 **Beautiful Deep Mind (BDM)** is an experimental cognitive architecture project.
@@ -22,10 +30,8 @@ Current milestone: `.ai/milestones.md`
 
 ## Current focus
 
-**Milestone 1 — Memory Core**
-
-Active work is in `packages/bdm-core/src/bdm/memory/`.
-Do not start work on `reflection/`, `self_model/`, or `continuity/` unless the user explicitly asks.
+See `.ai/current.md` — that file is the authoritative source of what is active right now.
+Never rely on this file for current task context; it may be stale. `current.md` is always up to date.
 
 ---
 
@@ -74,19 +80,16 @@ packages/
 
 ---
 
-## Commit message format
+## Naming conventions
 
+Branch names, issue titles, PR titles, commit messages: `.ai/git-conventions.md`
+
+Short version:
 ```
-<type>(<scope>): <short description>
-
-Types: feat, fix, test, docs, chore, refactor
-Scope: memory, reflection, self_model, continuity, cli, docs, ci
-
-Examples:
-feat(memory): add SQLite persistence to LongTermStore
-test(memory): add edge cases for ShortTermBuffer eviction
-fix(episodic): raise ValueError on empty summary
-docs(roadmap): update Milestone 1 status to in-progress
+branch:  feat/sqlite-long-term-store
+issue:   [feat] SQLite persistence for LongTermStore
+PR:      feat(memory): add SQLite persistence to LongTermStore (#12)
+commit:  feat(memory): add SQLite persistence to LongTermStore
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,24 +110,51 @@ Avoid wording such as:
 - "medical breakthrough";
 - "guaranteed cognitive improvement".
 
+## Naming Conventions
+
+Full conventions for branches, issues, PRs, and commits are in `.ai/git-conventions.md`.
+
+**Branch:**
+```
+feat/sqlite-long-term-store
+fix/short-term-buffer-eviction-index
+docs/manifesto-consciousness-framing
+research/h6-memory-reconstruction
+probe/continuity-cross-session
+```
+
+**Issue title:**
+```
+[feat] SQLite persistence for LongTermStore
+[bug] ShortTermBuffer leaves stale index entry after eviction
+[research] Design experiment for H6 — memory reconstruction
+[probe] Cross-session continuity probe
+```
+
+**PR title:**
+```
+feat(memory): add SQLite persistence to LongTermStore (#12)
+fix(memory): remove stale index entry on buffer eviction (#8)
+docs(manifesto): reframe primary goal around consciousness research (#3)
+```
+
 ## Pull Request Process
 
 Before opening a pull request:
 
-1. Check existing issues and discussions.
-2. Make sure your change is aligned with the project scope.
-3. Keep the pull request small and focused.
-4. Explain what you changed and why.
-5. Mention any limitations or assumptions.
-6. Confirm that you agree with the contribution terms.
+1. Check existing issues — open one first if it does not exist.
+2. Make sure your change is aligned with the current milestone (`.ai/current.md`).
+3. Keep the pull request small and focused — one issue per PR.
+4. All tests must pass before requesting review.
+5. PR title must reference the issue number.
+6. Use `.github/PULL_REQUEST_TEMPLATE.md` for the description.
 
-A pull request should include:
+A pull request must include:
 
-- a clear title;
-- a short summary;
-- the reason for the change;
-- affected files;
-- any relevant notes or limitations.
+- a title in the format above;
+- `Closes #n` in the description;
+- a summary of what changed and why;
+- any limitations or open questions.
 
 ## Pull Request Checklist
 

--- a/README.md
+++ b/README.md
@@ -1,68 +1,61 @@
 # Beautiful Deep Mind (BDM)
 
-An experimental cognitive architecture project exploring software models of memory, learning, attention, reflection, self-modeling, and continuity of internal context.
+An experimental cognitive architecture and research framework for investigating what consciousness is and why current computational systems cannot be minds the way a human brain is.
 
 ---
 
 ## What is BDM?
 
-BDM is a research and software project that attempts to model certain properties of cognition — memory, attention, reflection, learning, and context continuity — as composable software layers. It does not simulate a brain. It does not create consciousness. It explores whether structured approaches to memory and self-modeling might make software systems more coherent, consistent, and context-aware over time.
+BDM asks one central question:
 
-The project began as a long-standing personal question: if the brain's most interesting properties are its ability to remember, reflect, learn, and maintain a continuous sense of context — can those properties be modeled, even imperfectly, in software?
+> What is consciousness, and why can a computer — at least as we currently build them — not have it the way a human brain does?
 
-BDM is the attempt to take that question seriously.
+The framework (persistent memory, reflection loops, self-modeling, context continuity) is an instrument of investigation, not a product. It is built to probe the boundary between computation and cognition — to study where software models of cognitive properties succeed, where they fail, and what those failures reveal.
+
+BDM does **not** claim to create consciousness. It does **not** make medical claims. It is software research.
 
 ---
 
 ## What BDM Is Not
 
-- Not a medical product or medical research tool
+- Not a medical product or clinical tool
+- Not a consciousness engine or proof of machine sentience
 - Not a brain simulation or connectome model
-- Not a consciousness engine or claim to create conscious systems
-- Not a brain-computer interface (BCI) project
 - Not a mind-upload or mind-transfer technology
-- Not a replacement for neuroscience or cognitive science research
-- Not production software (currently in early conceptual/research phase)
+- Not a general-purpose AI assistant
+- Not production software (early research phase)
 
 ---
 
 ## Main Goals
 
-1. Design a conceptual architecture for cognitive-inspired software layers
-2. Prototype a persistent memory model that can store and retrieve structured experience
-3. Explore reflection loops that allow a system to reason about its own prior outputs
-4. Investigate self-modeling as a way for a system to represent its own state
-5. Study continuity of internal context across sessions and interactions
-6. Integrate these concepts with large language models (LLMs) as a research substrate
-7. Publish findings, experiments, and limitations openly
+1. Explore whether persistent memory, reflection, self-modeling, and continuity produce measurably different system behavior
+2. Study where software analogues of cognitive properties break down and what that reveals
+3. Investigate the structural gap between computational memory and biological memory
+4. Probe the boundary between capable computation and genuine cognition
+5. Publish all findings — including negative results — openly
 
 ---
 
-## Conceptual Modules (Early Stage)
+## Conceptual Modules
 
 | Module | Description |
 |---|---|
 | Memory Layer | Stores episodic, semantic, and working memory structures |
 | Attention Layer | Selects relevant context from memory and input |
-| Reflection Layer | Reviews prior outputs and applies correction or consistency checks |
+| Reflection Layer | Reviews prior outputs for consistency |
 | Learning Loop | Updates internal state based on feedback and new experience |
-| Self-Model Layer | Maintains a lightweight representation of the system's own state |
-| Context Continuity | Preserves thread of context across time and sessions |
-| Interface Layer | Connects these layers to external inputs and LLMs |
+| Self-Model Layer | Maintains a lightweight record of the system's own state |
+| Context Continuity | Preserves thread of context across sessions |
+| Interface Layer | Connects layers to external inputs and LLMs |
 
 ---
 
 ## Repository Status
 
-**Early conceptual and research phase.**
+**Milestone 1 — Memory Core — in progress.**
 
-No application code exists yet. The current focus is documentation, theoretical framing, and research direction. All architectural descriptions are conceptual. All hypotheses are untested.
-
----
-
-## Disclaimer
-
-BDM does not make medical claims. It does not claim to create, simulate, or replicate consciousness. It does not claim that software can copy, upload, transfer, or preserve a human mind. This project is software research inspired by cognitive science concepts. All claims are framed as hypotheses or research directions, not established results.
+M0 (documentation and foundation) is complete. Active work is in `packages/bdm-core/src/bdm/memory/`.
 
 ---
 
@@ -71,27 +64,87 @@ BDM does not make medical claims. It does not claim to create, simulate, or repl
 ```
 bdm/
 ├── README.md
+├── CLAUDE.md                       — Claude Code session context
+├── CONTRIBUTING.md                 — contribution rules
+├── LICENSE.md                      — source-available, all rights reserved
+│
+├── .ai/                            — AI assistant context directory
+│   ├── README.md
+│   ├── project.md                  — project overview and goals
+│   ├── behavior.md                 — rules for AI assistants
+│   ├── architecture.md             — architectural decisions
+│   ├── milestones.md               — milestone status tracker
+│   ├── current.md                  — active task and focus
+│   ├── git-conventions.md          — branch, issue, PR naming
+│   └── specs/                      — per-module specifications
+│       ├── memory-event.md
+│       ├── memory-store.md
+│       ├── reflection-loop.md
+│       ├── self-model.md
+│       └── continuity.md
+│
 ├── docs/
-│   ├── manifesto.md        — why this project exists
-│   ├── theory.md           — theoretical foundations
-│   ├── roadmap.md          — phased development plan
-│   ├── glossary.md         — key terms
-│   ├── architecture.md     — conceptual system architecture
-│   └── ethics.md           — responsible research guidelines
-├── research/
-│   ├── hypotheses.md       — initial research hypotheses
-│   ├── experiments.md      — experiment designs
-│   └── reading-list.md     — relevant literature by category
+│   ├── en/                         — English documentation
+│   │   ├── manifesto.md
+│   │   ├── theory.md
+│   │   ├── roadmap.md
+│   │   ├── glossary.md
+│   │   ├── architecture.md
+│   │   └── ethics.md
+│   └── pl/                         — Dokumentacja po polsku
+│       ├── manifest.md
+│       ├── teoria.md
+│       ├── mapa-drogowa.md
+│       ├── slownik.md
+│       ├── architektura.md
+│       └── etyka.md
+│
 ├── concepts/
-│   ├── memory.md
-│   ├── attention.md
-│   ├── reflection.md
-│   ├── learning-loop.md
-│   ├── self-model.md
-│   └── continuity.md
-├── CONTRIBUTING.md
-├── .gitignore
-└── LICENSE.md
+│   ├── en/                         — English concept files
+│   │   ├── memory.md
+│   │   ├── attention.md
+│   │   ├── reflection.md
+│   │   ├── learning-loop.md
+│   │   ├── self-model.md
+│   │   └── continuity.md
+│   └── pl/                         — Koncepcje po polsku
+│       ├── pamiec.md
+│       ├── uwaga.md
+│       ├── refleksja.md
+│       ├── petla-uczenia.md
+│       ├── model-siebie.md
+│       └── ciaglosc.md
+│
+├── research/
+│   ├── en/                         — English research documents
+│   │   ├── hypotheses.md
+│   │   ├── experiments.md
+│   │   └── reading-list.md
+│   └── pl/                         — Dokumenty badawcze po polsku
+│       ├── hipotezy.md
+│       ├── eksperymenty.md
+│       └── lista-lektur.md
+│
+├── packages/
+│   ├── bdm-core/                   — Core cognitive architecture package
+│   │   ├── pyproject.toml
+│   │   ├── src/bdm/
+│   │   │   ├── memory/             — M1: MemoryEvent, stores, episodic (active)
+│   │   │   ├── reflection/         — M2: ReflectionLoop (stub)
+│   │   │   ├── self_model/         — M3: SelfModelState (stub)
+│   │   │   └── continuity/         — M4: ContinuityContext (stub)
+│   │   └── tests/
+│   └── examples/
+│       └── memory_demo.py
+│
+├── .github/
+│   ├── ISSUE_TEMPLATE/
+│   │   ├── task.md
+│   │   ├── bug.md
+│   │   └── experiment.md
+│   └── PULL_REQUEST_TEMPLATE.md
+│
+└── .gitignore
 ```
 
 ---
@@ -108,3 +161,9 @@ See:
 
 - [`LICENSE.md`](./LICENSE.md)
 - [`CONTRIBUTING.md`](./CONTRIBUTING.md)
+
+---
+
+## Disclaimer
+
+BDM does not make medical claims. It does not claim to create, simulate, or replicate consciousness. It does not claim that software can copy, upload, transfer, or preserve a human mind. This project is software research inspired by cognitive science concepts. All claims are framed as hypotheses or research directions, not established results.

--- a/concepts/pl/ciaglosc.md
+++ b/concepts/pl/ciaglosc.md
@@ -1,0 +1,47 @@
+# Ciągłość
+
+## Definicja
+
+Ciągłość, w kontekście BDM, oznacza zachowanie istotnego stanu wewnętrznego między sesjami, interakcjami lub w czasie. System ma ciągłość, jeśli informacje z wcześniejszych interakcji mogą wpływać na bieżące zachowanie w sposób strukturalny, możliwy do wyszukania i audytowania.
+
+Ciągłość nie oznacza doskonałej pamięci wszystkiego. Oznacza, że istotny wcześniejszy stan jest dostępny, a nie utracony, gdy zaczyna się nowa sesja.
+
+---
+
+## Dlaczego ma znaczenie
+
+Bez ciągłości każda sesja zaczyna od zera. System nie może odwoływać się do wcześniejszych zobowiązań, budować na wcześniejszych wymianach, korygować błędów z poprzednich interakcji ani akumulować wiedzy w czasie. To fundamentalne ograniczenie dla każdego systemu mającego być użytecznym przez wiele sesji lub przez dłuższy czas.
+
+Ciągłość to również właściwość, która najściślej łączy projekt BDM z pytaniem poznawczym, które pierwotnie go zainspirowało: jak umysł utrzymuje spójne poczucie kontekstu i tożsamości w czasie? W systemach biologicznych jest to wspierane przez konsolidację pamięci, długoterminowe wzmacnianie synaptyczne i trwałość zapisów epizodycznych. W BDM ciągłość to decyzja projektowa oprogramowania.
+
+Co ważne, ciągłość to nie to samo co niezmienność. System z dobrą ciągłością może aktualizować, rewidować i zapominać — ale robi to w sposób strukturalny i zasadniczy, nie przez arbitralne tracenie stanu.
+
+---
+
+## Możliwa reprezentacja w oprogramowaniu
+
+Warstwa ciągłości kontekstu BDM byłaby odpowiedzialna za:
+
+1. **Serializację sesji:** Na końcu każdej sesji serializacja aktywnego stanu zasobu pamięci, modelu siebie i podsumowania interakcji do trwałego przechowywania
+2. **Odtwarzanie sesji:** Na początku nowej sesji ładowanie utrwalonego stanu i wstrzykiwanie skompresowanego podsumowania wcześniejszego kontekstu do bieżącej sesji
+3. **Protokół zimnego startu:** Przy uruchamianiu po długiej przerwie produkowanie "briefu wznowienia" — zwartego podsumowania najbardziej istotnego wcześniejszego stanu — zamiast próby wstrzyknięcia pełnej historii
+4. **Zarządzanie przestarzałością:** Oznaczanie zapisów jako przestarzałych po konfigurowalnych progach czasowych, tak by stare informacje nie były prezentowane jako aktualne
+5. **Obsługa wycofywania:** Utrzymywanie punktów kontrolnych, aby uszkodzony lub zdegradowany stan mógł być przywrócony do poprzedniego dobrze-działającego punktu
+
+---
+
+## Otwarte pytania
+
+- Ile wcześniejszego kontekstu powinno być odtwarzane przy starcie sesji? Pełna historia jest niepraktyczna; zbyt mało niweczy cel
+- Jak system powinien obsługiwać długie przerwy (dni, tygodnie) między sesjami, gdzie wiele wcześniejszego kontekstu może być przestarzałych lub nieistotnych?
+- Co definiuje granicę sesji? Oparta na czasie, tematyczna, jawna akcja użytkownika, czy kombinacja?
+- Jak warstwa ciągłości powinna wchodzić w interakcję z wymogiem prywatności, że użytkownicy mogą przeglądać i usuwać przechowywany stan?
+- Co się dzieje, gdy zasób pamięci rośnie bardzo przez wiele sesji — jak powinien być kompresowany lub przycinany bez utraty krytycznego kontekstu?
+
+---
+
+## Związek z BDM
+
+Ciągłość to warstwa, która sprawia, że pamięć, model siebie i pętla uczenia się BDM są użyteczne w czasie, a nie tylko w obrębie jednej sesji. Bez ciągłości wszystkie inne warstwy resetują się na końcu sesji. Z ciągłością system akumuluje doświadczenie, utrzymuje spójność w czasie i wykazuje adaptacyjne zachowanie, którego bezstanowy system nie może.
+
+Ciągłość to również miejsce, gdzie obawy o prywatność i bezpieczeństwo są najbardziej aktualne: co jest przechowywane, jak jest chronione i jak może być usunięte — to pytania projektowe, które muszą być rozwiązane równolegle z techniczną implementacją.

--- a/concepts/pl/model-siebie.md
+++ b/concepts/pl/model-siebie.md
@@ -1,0 +1,48 @@
+# Model siebie
+
+## Definicja
+
+Model siebie, tak jak jest używany w BDM, to strukturalna reprezentacja danych własnego stanu systemu: jakie tematy ma przechowywane informacje, jakie poziomy pewności wiążą się z przechowywanymi przekonaniami, jakie ograniczenia zostały odnotowane i jak wygląda historia ostatnich interakcji z perspektywy systemu.
+
+Model siebie to struktura danych. Nie jest samoświadomością. Nie jest świadomością. Nie jest subiektywnym poczuciem istnienia. To zapis — utrzymywany i odpytywalny — własnego stanu wiedzy systemu.
+
+---
+
+## Dlaczego ma znaczenie
+
+Systemy pozbawione jakiejkolwiek reprezentacji własnego stanu nie mogą dokładnie rozumować o tym, co wiedzą i czego nie wiedzą. LLM w szczególności są znane z produkowania pewnie brzmiących wyjść nawet w dziedzinach, gdzie ich wiedza jest nieobecna lub słaba. Model siebie śledzący znane luki wiedzy, poziomy pewności i uznane ograniczenia mógłby dostarczać jawnych sygnałów ograniczających wyjścia w niepewnych dziedzinach, prowadząc do bardziej odpowiednio ostrożnych i dokładnych odpowiedzi.
+
+Poza reprezentacją niepewności model siebie umożliwia pewien rodzaj spójności: system może skonsultować swój model siebie przed zaangażowaniem się w twierdzenie i zidentyfikować, czy to twierdzenie jest sprzeczne z zapisanymi wcześniejszymi stanowiskami.
+
+---
+
+## Możliwa reprezentacja w oprogramowaniu
+
+Minimalny model siebie w BDM mógłby zawierać:
+
+- **Inwentarz tematów:** lista tematów, o których system ma przechowywane zapisy, ze wskaźnikami pokrycia (wysoki, średni, niski, brak)
+- **Rejestr pewności:** dla kluczowych przechowywanych przekonań, wynik pewności odzwierciedlający jak dobrze przekonanie jest poparte przechowywanym dowodem
+- **Dziennik ograniczeń:** zapis jawnie uznanych luk, otrzymanych korekt i obszarów, gdzie system produkował niespójne wyjścia w przeszłości
+- **Podsumowanie interakcji:** zwarte podsumowanie ostatnich wzorców interakcji — jakie tematy były omawiane, jakie korekty otrzymano, jakie otwarte pytania pozostają
+
+Model siebie byłby wstrzykiwany do kontekstu LLM jako strukturalne podsumowanie, dając modelowi dostęp do reprezentacji własnego stanu bez konieczności każdorazowego wnioskowania tego stanu od zera.
+
+---
+
+## Otwarte pytania
+
+- Jaki jest minimalny schemat czyniący model siebie użytecznym bez jego nadmiernego rozrastania?
+- Jak powinny być przypisywane i aktualizowane wyniki pewności? Oparte na regułach, wspomagane LLM, czy obie?
+- Jak zapobiegamy dryfowi modelu siebie — gdzie staje się niedokładny w czasie, bo aktualizacje są pominięte lub nieprawidłowe?
+- Czy model siebie jest eksponowany LLM bezpośrednio (wstrzykiwany do promptu), używany jako filtr przed promptowaniem, czy obie?
+- Jakie jest ryzyko nadmiernego polegania LLM na modelu siebie i odmawiania angażowania się w tematy niereprezentowane w nim?
+
+---
+
+## Związek z BDM
+
+Warstwa modelu siebie zależy od warstwy pamięci (jest z niej wyprowadzona), pętli uczenia się (jest aktualizowana przez zdarzenia uczenia) i refleksji (zdarzenia refleksji zasilają dziennik ograniczeń). Zasila warstwę interfejsu, dostarczając strukturalnego kontekstu o bieżącym stanie systemu do wstrzyknięcia do promptów LLM.
+
+Model siebie jest jednym z bardziej nowatorskich komponentów BDM — ma analogi w kognitywistyce (metapoznanie, samomonitorowanie), ale mniej wyraźny precedens w obecnym projektowaniu systemów AI jako pierwszoklasowej warstwy architektonicznej.
+
+**Przypomnienie:** posiadanie modelu siebie nie czyni systemu samoświadomym. Model siebie to zapis stanu, nie jego doświadczenie.

--- a/concepts/pl/pamiec.md
+++ b/concepts/pl/pamiec.md
@@ -1,0 +1,46 @@
+# Pamięć
+
+## Definicja
+
+Pamięć to zdolność do kodowania, przechowywania i odtwarzania informacji. W kognitywistyce pamięć nie jest jednym systemem, lecz zbiorem funkcjonalnie odrębnych procesów i struktur o różnych cechach: czasie trwania, pojemności, mechanizmach kodowania i trybach wyszukiwania.
+
+---
+
+## Dlaczego ma znaczenie
+
+Pamięć to fundament ciągłości. Bez zdolności do zachowania informacji z wcześniejszych doświadczeń system nie może się adaptować, utrzymywać spójności ani budować na wcześniejszej wiedzy. W systemach biologicznych pamięć umożliwia tożsamość, uczenie się i zachowanie zorientowane na cel w czasie. W systemach oprogramowania pamięć jest zazwyczaj albo nieobecna (obliczenia bezstanowe), albo niezróżnicowana (płaskie logi lub proste magazyny klucz-wartość).
+
+Główna hipoteza BDM: struktura pamięci ma znaczenie, nie tylko jej obecność. Rozróżnianie zapisów epizodycznych od faktów semantycznych, indeksowanie według istotności i aktualności, zarządzanie politykami retencji — to hipoteza zakłada, że produkuje jakościowo lepsze zachowanie wyszukiwania niż płaskie przechowywanie.
+
+---
+
+## Możliwa reprezentacja w oprogramowaniu
+
+Zasób pamięci BDM zawierałby prawdopodobnie:
+
+- **Zapisy epizodyczne:** Strukturalne wpisy rejestrujące konkretne zdarzenia interakcji z polami na sygnaturę czasową, tagi tematyczne, wynik istotności i podsumowanie tego, co miało miejsce
+- **Zapisy semantyczne:** Ogólna wiedza i koncepcje, przechowywane z atrybucją źródła, poziomem pewności i sygnaturą czasową ostatniej weryfikacji
+- **Bufor pamięci roboczej:** Krótkotrwałe, wysokopriorytetowe okno kontekstowe zawierające najnowszy stan interakcji, opróżniane do zapisów epizodycznych na końcu sesji
+
+Wyszukiwanie obsługiwałoby wiele trybów zapytań:
+- Ważone aktualnością: zwracanie najnowszych zapisów
+- Ważone istotnością: zwracanie zapisów najbardziej podobnych do bieżącego zapytania
+- Filtrowane typem: zwracanie tylko epizodycznych, tylko semantycznych lub tylko zapisów pamięci roboczej
+
+---
+
+## Otwarte pytania
+
+- Jaki jest minimalny schemat dla zapisu epizodycznego, który jest zarówno informatywny, jak i obliczeniowo wykonalny?
+- Jak powinny być przypisywane i aktualizowane w czasie wyniki istotności?
+- Jaka jest właściwa polityka retencji zapobiegająca nieograniczonemu wzrostowi bez utraty ważnych zapisów?
+- Jak powinny być rozwiązywane sprzeczności między przechowywanymi zapisami?
+- Czy wyszukiwanie oparte na embeddingach jest konieczne od początku, czy prostsze indeksowanie słów kluczowych wystarczy dla wstępnych prototypów?
+
+---
+
+## Związek z BDM
+
+Pamięć to pierwsza warstwa architektury BDM i warunek wstępny dla wszystkich innych warstw. Uwaga wyszukuje z pamięci. Refleksja porównuje z pamięcią. Pętla uczenia się aktualizuje pamięć. Model siebie podsumowuje stan pamięci. Ciągłość kontekstu zachowuje pamięć między sesjami.
+
+Wszystko w BDM zależy od jakości warstwy pamięci. To komponent o najwyższym priorytecie w fazie 1 developmentu.

--- a/concepts/pl/petla-uczenia.md
+++ b/concepts/pl/petla-uczenia.md
@@ -1,0 +1,52 @@
+# Pętla uczenia się
+
+## Definicja
+
+Pętla uczenia się to mechanizm, przez który system aktualizuje swój stan wewnętrzny na podstawie nowych informacji, informacji zwrotnych lub wyników z interakcji. W BDM uczenie się nie odnosi się do gradientu ani aktualizacji wag modelu. Odnosi się do strukturalnych modyfikacji przechowywanych danych: aktualizowania przekonań, rewizji wyników istotności, zapisywania nowych zdarzeń epizodycznych, propagowania korekt z decyzji refleksji.
+
+---
+
+## Dlaczego ma znaczenie
+
+System, który nie może aktualizować swojego stanu wewnętrznego, jest statyczny. Może działać dobrze w jednej sesji, ale nie może się poprawiać na podstawie informacji zwrotnych, adaptować do nowych informacji ani korygować wcześniejszych błędów w czasie. Uczenie się — nawet w ograniczonym sensie aktualizowania przechowywanych zapisów — to mechanizm, przez który system staje się dokładniejszy i bardziej użyteczny w kolejnych interakcjach.
+
+Pętla uczenia się to również mechanizm, przez który inne warstwy BDM wzajemnie na siebie wpływają: decyzje refleksji zasialją aktualizacje pamięci, informacje zwrotne użytkownika aktualizują wyniki istotności, a nowe zdarzenia epizodyczne rozszerzają zasób pamięci.
+
+---
+
+## Możliwa reprezentacja w oprogramowaniu
+
+Pętla uczenia się w BDM działałaby jako mechanizm aktualizacji sterowany zdarzeniami:
+
+**Wyzwalacze uczenia:**
+- Jawna informacja zwrotna użytkownika (korekta, potwierdzenie lub oznaczenie)
+- Wyjście modułu refleksji (wykryta niespójność, wygenerowana rewizja)
+- Nowe zdarzenie epizodyczne na końcu sesji
+- Zaplanowany przegląd (np. zanikanie istotności)
+
+**Typy aktualizacji:**
+- **Aktualizacja przekonania:** modyfikacja lub zastąpienie przechowanego zapisu semantycznego, gdy potwierdzone są nowe sprzeczne informacje
+- **Aktualizacja istotności:** zwiększenie lub zmniejszenie wyniku istotności zapisu pamięci na podstawie częstości wyszukiwania lub informacji zwrotnych użytkownika
+- **Dołączanie epizodyczne:** zapisanie nowego zapisu epizodycznego podsumowującego zakończoną interakcję
+- **Rozwiązywanie niespójności:** oznaczanie sprzecznych zapisów, archiwizowanie zastąpionej wersji i promowanie zrewidowanej
+
+**Logowanie:**
+Każda aktualizacja powinna być logowana: co się zmieniło, co wywołało zmianę, kiedy i jaki był poprzedni stan. Jest to warunek konieczny dla możliwości audytu i cofnięcia.
+
+---
+
+## Otwarte pytania
+
+- Co liczy się jako "informacja zwrotna" do wywołania aktualizacji uczenia? Tylko jawne korekty, czy też sygnały niejawne?
+- Jak zapobiegamy temu, by pętla uczenia się wprowadzała systematyczny dryft — gdzie wczesne nieprawidłowe przekonania propagują się i się kumulują?
+- Jaki jest mechanizm wycofywania, gdy aktualizacja uczenia okazuje się nieprawidłowa?
+- Jak wykrywamy, gdy pętla uczenia się degraduje, a nie poprawia wydajność?
+- Czy istnieje punkt, w którym skumulowane aktualizacje wymagają pełnego przeglądu spójności, a nie aktualizacji przyrostowych?
+
+---
+
+## Związek z BDM
+
+Pętla uczenia się siedzi w centrum architektury BDM jako mechanizm utrzymujący aktualne wszystkie inne warstwy. Konsumuje wyjście z refleksji i z warstwy interfejsu, i zapisuje z powrotem do warstwy pamięci i warstwy modelu siebie. Bez pętli uczenia się BDM byłby systemem tylko do odczytu: zdolnym do pobierania i używania przechowywanych wiedzy, ale niezdolnym do jej aktualizowania na podstawie doświadczenia.
+
+Pętla uczenia się to to, co sprawia, że system jest adaptacyjny, a nie tylko trwały.

--- a/concepts/pl/refleksja.md
+++ b/concepts/pl/refleksja.md
@@ -1,0 +1,51 @@
+# Refleksja
+
+## Definicja
+
+Refleksja to zdolność do przeglądania i rozumowania o własnych wcześniejszych wyjściach, procesach rozumowania lub stanie wiedzy. W kognitywistyce metapoznanie — myślenie o myśleniu — to szerszy framework, w którym mieści się refleksja. W BDM refleksja jest zdefiniowana węziej jako proces obliczeniowy: dane kandydujące wyjście, porównaj je z wcześniejszymi wyjściami i oznacz lub popraw niespójności.
+
+---
+
+## Dlaczego ma znaczenie
+
+Systemy generujące wyjścia bez przeglądania ich pod kątem spójności mogą dryfować w czasie. Pojedyncza sesja z dobrze skalibrowanym systemem może wyglądać spójnie. Ale przez wiele sesji i wielu tematów, bez żadnego mechanizmu sprawdzania spójności, sprzeczności się kumulują. System może stwierdzać X w jednym kontekście i nie-X w innym, bez mechanizmu wykrywania ani rozwiązywania konfliktu.
+
+Refleksja to mechanizm adresujący ten problem. Nie chodzi o osiągnięcie filozoficznej samoświadomości — chodzi o implementację strukturalnego przeglądu, który wychwytuje wykrywalne niespójności zanim trafią do użytkowników.
+
+---
+
+## Możliwa reprezentacja w oprogramowaniu
+
+Moduł refleksji w BDM byłby implementowany jako krok post-przetwarzania w pipeline wyjść:
+
+1. Kandydujące wyjście jest generowane przez LLM
+2. Moduł refleksji pobiera wcześniejsze wyjścia na ten sam lub powiązane tematy z zasobu pamięci
+3. Moduł refleksji porównuje kandydujące wyjście z wcześniejszymi wyjściami
+4. W przypadku wykrycia potencjalnej niespójności moduł produkuje raport refleksji:
+   - `consistent` — nie wykryto sprzeczności, wyjście zatwierdzone
+   - `inconsistent` — wykryto sprzeczność, oznacz do rewizji
+   - `uncertain` — porównanie niejednoznaczne, oznacz do przeglądu
+5. W przypadku niespójności moduł opcjonalnie generuje zrewidowane wyjście lub przekazuje flagę dalej
+
+Krok porównania mógłby być:
+- **Oparty na regułach:** jawna detekcja sprzeczności (np. "A" vs. "nie A" dla tego samego faktu)
+- **Wspomagany LLM:** wtórny prompt prosi LLM o porównanie kandydata z wcześniejszymi wyjściami i ocenę spójności
+- **Hybrydowy:** detekcja oparta na regułach dla rażących sprzeczności, wspomagana LLM dla subtelnych
+
+---
+
+## Otwarte pytania
+
+- Czy refleksja powinna być blokująca (wstrzymuje wyjście do zakończenia przeglądu) czy asynchroniczna (oznacza niespójności po fakcie)?
+- Jak odróżnić uzasadnioną aktualizację wcześniejszego stanowiska od niespójności?
+- Jaki jest koszt obliczeniowy refleksji i w jakiej skali staje się niepraktyczna?
+- Czy refleksja może być rzetelnie ewaluowana? Jakie metryki mogą odróżnić dobrą refleksję od złej?
+- Czy istnieje ryzyko, że refleksja spowoduje, że wyjście stanie się nadmiernie ostrożne — konsekwentnie ostrożne zamiast angażowania się w stanowiska?
+
+---
+
+## Związek z BDM
+
+Refleksja to trzecia warstwa w architekturze BDM. Zależy od warstwy pamięci (do pobierania wcześniejszych wyjść do porównania) i warstwy uwagi (do efektywnego udostępniania istotnych wcześniejszych wyjść). Zasila pętlę uczenia się: gdy refleksja wykryje niespójność i zostanie dokonana rewizja, ta rewizja może wywołać aktualizację zasobu pamięci.
+
+Refleksja jest również ściśle związana z warstwą modelu siebie: model siebie może reprezentować znany rekord spójności systemu, a zdarzenia refleksji mogą go aktualizować.

--- a/concepts/pl/uwaga.md
+++ b/concepts/pl/uwaga.md
@@ -1,0 +1,49 @@
+# Uwaga
+
+## Definicja
+
+Uwaga to mechanizm, przez który system wybiera, które informacje są najbardziej istotne dla bieżącego zadania i alokuje odpowiednio zasoby przetwarzania. W kognitywistyce uwaga to selektywne filtrowanie bodźców z większej puli dostępnych wejść. W uczeniu maszynowym mechanizmy uwagi obliczają ważoną istotność między zapytaniem a zestawem elementów kandydujących, produkując skoncentrowany wybór istotnej treści.
+
+---
+
+## Dlaczego ma znaczenie
+
+Pamięć bez uwagi jest prawie bezużyteczna. System może przechowywać dużą liczbę zapisów, ale jeśli nie może wybrać właściwych zapisów we właściwym czasie, przechowywanie nie przynosi żadnej korzyści. Uwaga to strategia wyszukiwania — mechanizm łączący to, co jest przechowywane z tym, co jest aktualnie potrzebne.
+
+W systemach opartych na LLM uwaga działa wewnątrz okna kontekstowego na tokenach wejściowych. Warstwa uwagi BDM działa na innym poziomie: nad trwałym zasobem pamięci, wybierając które przechowywane zapisy powinny być udostępnione i wstrzyknięte do bieżącego kontekstu interakcji.
+
+---
+
+## Możliwa reprezentacja w oprogramowaniu
+
+W BDM warstwa uwagi działałaby jako procesor zapytań nad zasobem pamięci:
+
+1. Odbieranie bieżącego wejścia lub zadania jako zapytania
+2. Obliczanie wyników istotności dla przechowywanych zapisów pamięci względem zapytania
+3. Rankingowanie i filtrowanie zapisów według istotności, aktualności lub innych konfigurowalnych kryteriów
+4. Zwracanie ograniczonego zestawu wysokoisotnych zapisów do wstrzyknięcia do kontekstu downstream
+5. Logowanie decyzji wyszukiwania dla możliwości audytu
+
+Obliczanie istotności mogłoby używać:
+- **Nakładania słów kluczowych:** proste dopasowanie terminów między zapytaniem a treścią zapisu
+- **Podobieństwa embeddingowego:** kosinusowe podobieństwo między embeddingami zapytania i zapisu
+- **Ważenia aktualnością:** nowsze zapisy otrzymują wzmocnienie istotności
+- **Oceniania istotnością:** zapisy oznaczone jako wysokoisotne przez pętlę uczenia są priorytetowane
+
+---
+
+## Otwarte pytania
+
+- Czy warstwa uwagi powinna używać jednej strategii wyszukiwania czy dynamicznie wybierać między strategiami na podstawie typu zapytania?
+- Jak oceniamy jakość wyszukiwania bez etykiet istotności ground truth?
+- Jaki jest właściwy górny limit pobranego kontekstu do wstrzyknięcia — zbyt dużo dodaje szum, zbyt mało traci ważny kontekst?
+- Czy uwaga powinna dalej filtrować pobrane zapisy (np. streszczać lub kompresować) przed wstrzyknięciem?
+- Jak powinny być obsługiwane sprzeczne pobrane zapisy — wstrzykiwane razem, oznaczane czy filtrowane?
+
+---
+
+## Związek z BDM
+
+Uwaga siedzi między warstwą pamięci a wszystkimi wyższymi warstwami. Jest odpowiedzialna za zapewnienie, że właściwe przechowywane informacje trafiają do właściwej części pipeline'u we właściwym czasie. Bez efektywnej uwagi pamięć staje się obciążeniem, a nie zasobem: duże, wolne i głośne.
+
+Dobry projekt warstwy uwagi jest prawdopodobnie jedną z najważniejszych decyzji inżynierskich w architekturze BDM.

--- a/docs/en/manifesto.md
+++ b/docs/en/manifesto.md
@@ -1,0 +1,103 @@
+# BDM Manifesto
+
+## The Origin
+
+This project comes from a question that has persisted for a long time: what makes the mind interesting is not its raw processing power, but its ability to remember, to learn from what it has experienced, to reflect on its own reasoning, and to maintain a coherent sense of self across time.
+
+That question is not new. Philosophers, neuroscientists, and engineers have approached it from many directions. But for this project, it started as something more personal — a long-standing fascination with how the brain works, what consciousness actually is, and why a computer — despite being able to perform tasks that once seemed to require a mind — still seems to be missing something fundamental.
+
+BDM is the attempt to take that question seriously as a research and engineering project.
+
+---
+
+## The Real Question
+
+The central question behind BDM is not "how do we build a better AI assistant."
+
+It is this:
+
+> What is consciousness, and why can a computer — at least as we currently build them — not have it the way a human brain does?
+
+This is one of the hardest open questions in science and philosophy. BDM does not claim to answer it. But it approaches it from a specific angle: by building software models of the properties that seem most relevant — memory, continuity, reflection, self-modeling — and studying where those models succeed, where they fail, and what those failures reveal about the gap between computation and cognition.
+
+The framework is an instrument of investigation, not a product. The goal is not to build something that is conscious. The goal is to understand, through building, why consciousness is not just a matter of having the right software.
+
+---
+
+## Why Memory, Continuity, Reflection, and Self-Modeling Matter
+
+If you try to describe what makes a human mind what it is, several properties stand out:
+
+- It remembers. Not just facts, but experiences — things that happened, in context, with emotional weight, at a specific time.
+- It is continuous. Your sense of being the same person who woke up yesterday is grounded in memory, in narrative, in a thread that connects past to present.
+- It reflects. You can think about your own thinking, catch yourself being inconsistent, revise your beliefs.
+- It has a model of itself. You know roughly what you know, what you don't know, what you're good at, what you're afraid of.
+
+Current AI systems — including the most capable large language models — have none of these properties in any durable sense. Each session starts blank. There is no yesterday. There is no accumulated experience. There is no thread.
+
+This is not a flaw in those systems. It is a consequence of how they are built. But it raises the question: if we gave a system these properties — real persistence, real continuity, real self-modeling — would it become more like a mind? And if not, what would still be missing?
+
+That is what BDM is trying to find out.
+
+---
+
+## Why Current AI Systems Are Not Brains
+
+A modern LLM processes language in ways that can look remarkably like reasoning, understanding, even creativity. But several things separate it from a biological brain in ways that go beyond raw capability:
+
+**No temporal experience.** A brain exists in time. It has a past it remembers and a future it anticipates. An LLM has a context window. Everything outside that window does not exist for it.
+
+**No embodiment.** A brain is connected to a body with senses, needs, drives, and a continuous stream of experience. Computation operates on tokens. There is no hunger, no pain, no pleasure, no urgency that comes from being alive.
+
+**No causal continuity.** When you learn something, physical changes occur in your brain — synaptic weights shift, connections strengthen or weaken. That change persists and shapes future processing. An LLM's weights are frozen after training. It does not change as a result of interacting with you.
+
+**No unified perspective.** There is something it is like to be you — a subjective point of view, an experiencing subject. Whether there is something it is like to be an LLM is not just unknown — it is not clear the question is even well-formed for current architectures.
+
+BDM treats these gaps as research questions, not settled conclusions. Some of them may be bridgeable through engineering. Others may point to something more fundamental about what consciousness requires — something that cannot be solved by adding a memory layer or a reflection module.
+
+The project is interested in finding out which is which.
+
+---
+
+## What the Framework Is For
+
+BDM builds software models of memory, attention, reflection, self-modeling, and continuity. These models are not claimed to be conscious. They are not claimed to replicate how the brain actually works.
+
+They are tools for asking questions:
+
+- If a system has persistent episodic memory, does its behavior become more coherent over time? If so, what does that tell us about the role of memory in cognition?
+- If a system has a self-model, does it represent its own limitations more accurately? If not, what is missing from the model?
+- If a system has continuity across sessions, does it develop something that looks like a consistent perspective? What would distinguish that from genuine identity?
+- At what point do these additions stop making a meaningful difference — and what does that boundary reveal?
+
+The framework is a laboratory. The experiments are hypotheses about cognition and consciousness. The results, whatever they are, will be published openly.
+
+---
+
+## What BDM Does Not Claim
+
+BDM does not claim to create consciousness or to prove that any system is conscious.
+
+BDM does not claim to replicate, copy, upload, transfer, or preserve a human mind.
+
+BDM does not make medical claims of any kind.
+
+BDM uses terms like "memory," "reflection," and "self-model" as descriptions of software components, not as claims that those components correspond to their biological counterparts in any deep sense. The analogy is useful. It is not literal.
+
+The project studies the question of consciousness. It does not answer it. Those are very different things.
+
+---
+
+## A Grounded Attempt
+
+The ambition behind BDM is genuine. But ambition does not require exaggeration.
+
+The most honest framing of this project is this: someone has had a long-standing fascination with the brain, consciousness, and the question of what separates computation from cognition. Rather than leaving that fascination as a private thought, they decided to treat it as a serious research problem — to define it precisely, document it carefully, build instruments to investigate it, and publish what is found.
+
+The project may produce useful software. It may produce interesting findings. It may produce only a clearer understanding of why the problem is harder than it looks.
+
+All of those outcomes are worth pursuing. The goal is to do the work honestly.
+
+---
+
+*BDM — Beautiful Deep Mind. Early research stage. All rights reserved.*

--- a/docs/pl/architektura.md
+++ b/docs/pl/architektura.md
@@ -1,0 +1,162 @@
+# Architektura konceptualna
+
+Niniejszy dokument opisuje konceptualną architekturę systemu BDM. To nie jest implementacja. Dla tej architektury nie istnieje jeszcze żaden kod (poza warstwą pamięci). Celem tego dokumentu jest zdefiniowanie warstw funkcjonalnych, wyjaśnienie ich odpowiedzialności i interfejsów oraz identyfikacja otwartych pytań projektowych dla każdej warstwy.
+
+Wszystkie opisy tu reprezentują intencje projektowe i hipotezy, nie zaimplementowane zachowanie.
+
+---
+
+## Przegląd
+
+Architektura BDM jest zorganizowana jako zestaw kompozytowalnych warstw funkcjonalnych. Każda warstwa ma odrębne przeznaczenie i komunikuje się z sąsiednimi przez zdefiniowane interfejsy.
+
+```
+┌─────────────────────────────────┐
+│         Warstwa interfejsu      │  ← wejście/wyjście użytkownika i LLM
+├─────────────────────────────────┤
+│       Ciągłość kontekstu        │  ← trwałość sesji
+├─────────────────────────────────┤
+│        Warstwa modelu siebie    │  ← reprezentacja stanu wewnętrznego
+├─────────────────────────────────┤
+│          Pętla uczenia się      │  ← aktualizacja przekonań, przetwarzanie informacji zwrotnych
+├─────────────────────────────────┤
+│         Warstwa refleksji       │  ← sprawdzanie spójności, przegląd
+├─────────────────────────────────┤
+│          Warstwa uwagi          │  ← pobieranie pamięci, selekcja kontekstu
+├─────────────────────────────────┤
+│           Warstwa pamięci       │  ← przechowywanie, indeksowanie, wyszukiwanie
+└─────────────────────────────────┘
+```
+
+---
+
+## Warstwa pamięci
+
+**Przeznaczenie:** Przechowywanie i wyszukiwanie strukturalnych zapisów doświadczeń, wiedzy i historii interakcji.
+
+**Możliwe odpowiedzialności:**
+- Utrzymywanie odrębnych typów zapisów: zapisy epizodyczne (zdarzenia interakcji z sygnaturą czasową), zapisy semantyczne (ogólna wiedza i koncepcje), bufor pamięci roboczej (aktywny kontekst sesji)
+- Zapewnianie interfejsu zapytań do wyszukiwania według aktualności, tematu, wyniku istotności lub typu zapisu
+- Zarządzanie wygasaniem zapisów, zanikaniem istotności i limitami przechowywania
+- Obsługa aktualizacji i rewizji przechowywanych zapisów, gdy nowe informacje zaprzeczają wcześniejszym
+- Prowadzenie dziennika audytu operacji pamięci
+
+**Otwarte pytania:**
+- Jaki schemat najlepiej oddaje zapisy epizodyczne bez nadmiernego narzutu?
+- Jak powinny być obliczane i aktualizowane wyniki istotności — oparte na regułach, embeddingach czy hybrydowo?
+- Jaka jest właściwa polityka retencji: zanikanie czasowe, jawne usuwanie czy przycinanie ważone pewnością?
+- Jak powinny być obsługiwane sprzeczności między przechowywanymi zapisami — oznaczane, scalane czy zastępowane?
+
+---
+
+## Warstwa uwagi
+
+**Przeznaczenie:** Wybór, które przechowywane wspomnienia i elementy kontekstowe są najbardziej istotne dla bieżącego wejścia, i udostępnianie ich do dalszego przetwarzania.
+
+**Możliwe odpowiedzialności:**
+- Odbieranie zapytania (bieżące wejście, zadanie lub pytanie) i zwracanie rankingowego zestawu istotnych zapisów pamięci
+- Stosowanie strategii wyszukiwania: ważonej aktualnością, opartej na podobieństwie semantycznym lub filtrowanej tematycznie
+- Ograniczanie pobranego kontekstu do tego, co mieści się w oknie kontekstowym systemu downstream
+- Prowadzenie dziennika wyszukiwania dla możliwości audytu
+
+**Otwarte pytania:**
+- Czy uwaga powinna używać jednej strategii wyszukiwania czy dynamicznie wybierać między strategiami w zależności od typu zapytania?
+- Jak oceniać jakość wyszukiwania bez etykiet istotności ground truth?
+- Co się dzieje, gdy pobrany kontekst jest sprzeczny?
+
+---
+
+## Warstwa refleksji
+
+**Przeznaczenie:** Przeglądanie wcześniejszych wyjść pod kątem spójności, oznaczanie rozbieżności i opcjonalne stosowanie korekt przed produkcją końcowego wyjścia.
+
+**Możliwe odpowiedzialności:**
+- Porównywanie kandydującego wyjścia z przechowywanymi wcześniejszymi wyjściami na ten sam lub powiązany temat
+- Wykrywanie jawnych sprzeczności (niespójności faktyczne) i ukrytych niespójności (zmiana stanowiska bez uzasadnienia)
+- Produkowanie raportu refleksji: spójny, niespójny lub niepewny
+- Opcjonalne rewizja wyjścia w celu rozwiązania wykrytych niespójności
+- Logowanie wszystkich zdarzeń refleksji dla audytu
+
+**Otwarte pytania:**
+- Czy refleksja powinna być krokiem blokującym (wyjście jest wstrzymane do zakończenia przeglądu) czy asynchronicznym?
+- Jak odróżnić uzasadnione aktualizacje wcześniejszych stanowisk od niespójności?
+- Jaka jest optymalna częstotliwość refleksji — przy każdym wyjściu, okresowo czy na żądanie?
+
+---
+
+## Pętla uczenia się
+
+**Przeznaczenie:** Aktualizacja przechowywanych stanów wewnętrznych na podstawie nowych informacji, informacji zwrotnych lub wyników z interakcji.
+
+**Możliwe odpowiedzialności:**
+- Przetwarzanie jawnych sygnałów informacji zwrotnych (korekty użytkownika, oznaczone błędy) i aktualizowanie istotnych zapisów pamięci
+- Dostosowywanie wyników istotności zapisów pamięci na podstawie częstości pobierania lub potwierdzenia
+- Zapisywanie nowych zdarzeń epizodycznych generowanych podczas interakcji
+- Propagowanie aktualizacji z decyzji refleksji z powrotem do warstwy pamięci
+- Prowadzenie dziennika zmian wszystkich zastosowanych aktualizacji
+
+**Otwarte pytania:**
+- Co liczy się jako informacja zwrotna? Tylko jawne korekty, czy też sygnały niejawne?
+- Jak powinny być rozwiązywane sprzeczne aktualizacje — wygrywa najnowsza, ważona pewnością czy ręcznie?
+- Jak zapobiegamy temu, by pętla uczenia się wprowadzała systematyczny dryft w czasie?
+
+---
+
+## Warstwa modelu siebie
+
+**Przeznaczenie:** Utrzymywanie strukturalnej reprezentacji własnego stanu systemu: co wie, czego nie wie, jakie tematy eksplorował i jakie poziomy pewności wiążą się z jego przechowywanymi przekonaniami.
+
+**Możliwe odpowiedzialności:**
+- Utrzymywanie inwentarza tematów: tematy, o których system ma przechowywane informacje
+- Śledzenie poziomów pewności dla przechowywanych przekonań, aktualizowanych przez pętlę uczenia się
+- Zapisywanie uznanych ograniczeń i znanych luk
+- Dostarczanie podsumowania stanu modelu siebie do użytku downstream (np. LLM może odwoływać się do niego przy formułowaniu odpowiedzi)
+
+**Otwarte pytania:**
+- Jaki jest minimalny schemat przydatnego modelu siebie? Co musi zawierać, co jest narzutem?
+- Jak poziomy pewności są przypisywane i aktualizowane w zasadniczy sposób?
+- Jak zapobiegamy temu, by model siebie stawał się niedokładny przez dryft?
+
+**Ważna uwaga:** Model siebie to struktura danych. Nie stanowi samoświadomości. Nie implikuje świadomości. To zapis stanu wewnętrznego, nie subiektywne doświadczenie tego stanu.
+
+---
+
+## Warstwa ciągłości kontekstu
+
+**Przeznaczenie:** Zachowanie istotnego stanu wewnętrznego między sesjami, tak aby nowa sesja zaczynała się z dostępem do wcześniejszego kontekstu, a nie od stanu pustego.
+
+**Możliwe odpowiedzialności:**
+- Serializacja i przechowywanie stanu sesji na końcu każdej interakcji
+- Odtwarzanie istotnego wcześniejszego stanu na początku nowej sesji, filtrowanego według aktualności i istotności
+- Stosowanie "protokołu zimnego startu": streszczanie wcześniejszego kontekstu do zwartej reprezentacji
+- Zarządzanie granicami sesji i przejściami
+- Obsługa wycofywania: przywracanie stanu do wcześniejszego punktu kontrolnego w przypadku wykrycia uszkodzenia lub błędu
+
+**Otwarte pytania:**
+- Ile wcześniejszego kontekstu powinno być przywracane? Pełna historia vs. filtrowane pod względem istotności streszczenie?
+- Co definiuje granicę sesji? Czasowa, tematyczna czy jawna akcja użytkownika?
+- Jak obsługujemy ciągłość po długich przerwach (dni, tygodnie), gdzie wiele wcześniejszego kontekstu może być nieaktualnych?
+- Implikacje prywatności: przechowywany stan sesji może zawierać wrażliwe treści — jak jest chroniony?
+
+---
+
+## Warstwa interfejsu
+
+**Przeznaczenie:** Łączenie wszystkich wewnętrznych warstw z zewnętrznymi wejściami (wiadomości użytkownika, wywołania API) i wyjściami (generowane odpowiedzi) oraz z LLM tam, gdzie ma to zastosowanie.
+
+**Możliwe odpowiedzialności:**
+- Odbieranie przychodzącego wejścia i kierowanie go przez pipeline przetwarzania
+- Wstrzykiwanie pobranego kontekstu pamięci i stanu modelu siebie do promptów LLM
+- Odbieranie wyjść LLM i przekazywanie ich do warstwy refleksji
+- Zwracanie końcowych wyjść do użytkownika lub systemu wywołującego
+- Udostępnianie interfejsu konfiguracji do włączania lub wyłączania warstw
+- Zapewnianie hooków logowania i obserwowalności do debugowania i ewaluacji
+
+**Otwarte pytania:**
+- Czy warstwa interfejsu powinna być od początku niezależna od LLM (zdolna do wymiany modelu)?
+- Jak powinno być strukturowane wstrzykiwanie kontekstu promptu — systemowy prompt, wiadomość użytkownika czy dedykowany format?
+- Jak zapobiegamy temu, by warstwa interfejsu stała się wąskim gardłem lub pojedynczym punktem awarii?
+
+---
+
+*Ta architektura jest konceptualna. Wszystkie opisy warstw reprezentują intencje projektowe. Na tym etapie implementacja nie istnieje dla większości warstw.*

--- a/docs/pl/etyka.md
+++ b/docs/pl/etyka.md
@@ -1,0 +1,138 @@
+# Etyka i odpowiedzialne badania
+
+Niniejszy dokument opisuje zasady etyczne i ograniczenia kierujące BDM jako projektem badawczym. To nie są deklaracje aspiracyjne — to wiążące wytyczne kształtujące to, co projekt twierdzi, jak się komunikuje, co buduje i czego odmawia robienia.
+
+---
+
+## Brak twierdzeń medycznych
+
+BDM nie jest produktem medycznym, narzędziem badań medycznych, instrumentem klinicznym ani zastosowaniem terapeutycznym.
+
+BDM nie twierdzi, że:
+- diagnozuje, leczy, zapobiega ani leczy jakiemukolwiek schorzeniu
+- poprawia funkcje poznawcze w jakimkolwiek mierzalnym klinicznie sensie
+- wspiera podejmowanie decyzji w ochronie zdrowia, psychologii lub neurologii
+- jest bezpieczny lub odpowiedni do zastosowań klinicznych lub terapeutycznych
+
+Każda osoba szukająca wsparcia w zakresie zdrowia poznawczego, oceny neurologicznej lub pomocy psychologicznej powinna skonsultować się z wykwalifikowanym specjalistą medycznym lub klinicznym.
+
+---
+
+## Brak twierdzeń o świadomości
+
+BDM nie twierdzi, że:
+- tworzy świadomość w systemie oprogramowania
+- symuluje świadomość ani przybliża subiektywnego doświadczenia
+- udowadnia, że system jest lub nie jest świadomy
+- produkuje systemy, które "czują", "doświadczają" lub mają stany wewnętrzne w jakimkolwiek znaczącym sensie
+
+Użycie terminów takich jak "umysł", "głęboki umysł", "model siebie" i "refleksja" w tym projekcie jest metaforyczne i funkcjonalne. Terminy te opisują wzorce projektowe oprogramowania, nie właściwości świadomości, wrażliwości ani subiektywnego doświadczenia.
+
+Projekt bada pytanie o świadomość. Nie twierdzi, że na nie odpowiada. To zasadnicza różnica.
+
+---
+
+## Brak twierdzeń o przesyłaniu umysłu
+
+BDM nie twierdzi, że:
+- kopiuje ludzki umysł do oprogramowania
+- przesyła, przenosi, zachowuje ani rozszerza ludzką świadomość
+- zapewnia jakąkolwiek ścieżkę do cyfrowej nieśmiertelności czy ciągłości umysłu
+- replikuje strukturę lub funkcję ludzkiego mózgu
+
+BDM to badania oprogramowania. Czerpie konceptualną inspirację z kognitywistyki, ale nie operuje na danych biologicznych i nie modeluje rzeczywistych procesów mózgowych. Różnica między "zainspirowanym koncepcjami kognitywnymi" a "replikującym mózg" jest kategoryczna — BDM jest zdecydowanie w pierwszej kategorii.
+
+---
+
+## Odpowiedzialny język
+
+BDM zobowiązuje się do używania starannego, precyzyjnego języka we wszelkiej dokumentacji, komentarzach do kodu, publikacjach i komunikacji.
+
+Oznacza to:
+- Formułowanie wszystkich niezweryfikowanych idei jako hipotez, nie faktów
+- Wyraźne rozróżnianie między modelem, symulacją a rzeczywistym poznaniem
+- Nieużywanie języka sugerującego świadomość lub doświadczenie w systemie oprogramowania
+- Nieużywanie języka generującego ekscytację kosztem dokładności
+- Explicite i wyraźne uznawanie ograniczeń
+- Aktualizowanie lub wycofywanie twierdzeń, gdy dowody ich nie wspierają
+
+Język do unikania: "system myśli", "system czuje", "system jest świadomy", "cyfrowa świadomość", "mózg w oprogramowaniu", "kopia umysłu", "cyfryczna dusza".
+
+Język preferowany: "system przechowuje", "system wyszukuje", "system modeluje", "system reprezentuje", "strukturalne przybliżenie", "warstwa konceptualna", "hipoteza badawcza".
+
+---
+
+## Kwestie prywatności
+
+Warstwy pamięci i ciągłości BDM będą przechowywać zapisy interakcji, w tym potencjalnie wrażliwe treści. Projekt traktuje to poważnie:
+
+- Zasoby pamięci nie powinny gromadzić ani przechowywać danych osobowych bez wyraźnej zgody
+- Przechowywane zapisy interakcji powinny być chronione przed nieautoryzowanym dostępem
+- Użytkownicy powinni mieć możliwość przeglądania, eksportowania i usuwania przechowywanych zapisów
+- Każdy eksperyment z danymi użytkowników musi działać w ramach jasnej polityki obsługi danych
+- BDM nie będzie udostępniał przechowywanych danych interakcji stronom trzecim bez wyraźnej zgody
+
+W miarę przejścia projektu z fazy konceptualnej do prototypu, konkretne protokoły obsługi danych będą dokumentowane i publikowane.
+
+---
+
+## Kwestie bezpieczeństwa
+
+BDM to projekt badawczy we wczesnej fazie. Kwestie bezpieczeństwa obejmują:
+
+- **Dryft behawioralny:** Pętla uczenia się aktualizująca przechowywane przekonania bez odpowiednich zabezpieczeń mogłaby wzmacniać nieprawidłowe lub szkodliwe przekonania w czasie. Wszystkie mechanizmy uczenia muszą zawierać logowanie, możliwość audytu i możliwość cofnięcia.
+- **Nadmierne poleganie:** Użytkownicy nie powinni być zachęcani do polegania na wynikach BDM przy podejmowaniu ważkich decyzji, szczególnie w dziedzinach takich jak zdrowie, prawo czy finanse.
+- **Błędy refleksji:** Moduł refleksji, który nieprawidłowo oznacza spójne wyjścia jako niespójne lub nie wykrywa prawdziwych niespójności, może degradować jakość wyjścia w nieoczywisty sposób.
+- **Ograniczenia modelu:** Poleganie BDM na LLM jako substracie oznacza, że dziedziczy wszystkie znane ograniczenia tych modeli, w tym halucynacje, uprzedzenia i ograniczenia okna kontekstowego.
+
+---
+
+## Badania skoncentrowane na człowieku
+
+BDM jest projektowany dla ludzi i przez ludzi, z myślą o potrzebach ludzkich i ludzkiej kontroli.
+
+Oznacza to:
+- Projekt nie dąży do autonomii kosztem przejrzystości
+- Użytkownicy powinni rozumieć, co system przechowuje, wyszukuje i nad czym rozumuje
+- Żaden komponent BDM nie powinien działać w sposób celowo nieprzejrzysty dla użytkowników i deweloperów
+- Celem jest budowanie użytecznego, uczciwego, podlegającego audytowi oprogramowania — nie maksymalizowanie możliwości bez względu na konsekwencje
+
+---
+
+## Przejrzystość i ograniczenia
+
+BDM zobowiązuje się do przejrzystości w kwestii tego, czym jest i czym nie jest:
+
+- Wszystkie opublikowane wyniki będą zawierać jasne stwierdzenie ograniczeń
+- Negatywne wyniki będą publikowane obok pozytywnych
+- Projekt nie będzie selekcjonować wyników, by przedstawić bardziej korzystny obraz
+- Opisy architektoniczne będą wyraźnie rozróżniać między zaimplementowanymi komponentami a konceptualnymi
+- Historia wersji i dzienniki zmian będą utrzymywane otwarcie
+
+---
+
+## Unikanie zwodniczego antropomorfizmu
+
+Antropomorfizm — przypisywanie ludzkich cech nieludzkim systemom — to znane ryzyko w badaniach i komunikacji AI. BDM zwraca uwagę na unikanie zwodniczego antropomorfizmu:
+
+- Warstwy oprogramowania nie będą opisywane tak, jakby miały doświadczenia, intencje ani uczucia
+- Interfejsy użytkownika nie będą projektowane tak, by tworzyć fałszywe wrażenie wrażliwości lub emocjonalnej reaktywności
+- Dokumentacja nie będzie używać języka zachęcającego użytkowników do tworzenia nieodpowiednich więzi lub poziomów zaufania do systemu
+
+Metafory funkcjonalne (np. "system reflektuje nad swoim wcześniejszym wyjściem") są akceptowalne, gdy są wyraźnie ujęte jako opisy procesów obliczeniowych, nie jako twierdzenia o wewnętrznych doświadczeniach.
+
+---
+
+## Symulacja, modelowanie i rzeczywiste poznanie
+
+Te trzy koncepcje są kategorycznie różne i BDM będzie utrzymywał to rozróżnienie przez cały czas:
+
+- **Symulacja** — proces oprogramowania naśladujący pewne obserwowalne zachowania systemu, niekoniecznie implementujący te same mechanizmy
+- **Modelowanie** — strukturalna reprezentacja wybranych właściwości systemu, wyabstrahowana z pełnej złożoności
+- **Rzeczywiste poznanie** — procesy zachodzące w biologicznych mózgach, obejmujące mechanizmy, które nie są jeszcze w pełni rozumiane
+
+BDM buduje modele. Może produkować symulacje pewnych zachowań poznawczych. Nie replikuje, nie uzyskuje dostępu ani nie odtwarza rzeczywistego poznania.
+
+---
+
+*Ten dokument będzie aktualizowany w miarę rozwoju projektu. Etyka nie jest jednorazową deklaracją — wymaga ciągłej uwagi, rewizji i odpowiedzialności.*

--- a/docs/pl/manifest.md
+++ b/docs/pl/manifest.md
@@ -1,0 +1,103 @@
+# Manifest BDM
+
+## Skąd to się wzięło
+
+Ten projekt wyrasta z pytania, które nie daje spokoju od dawna: co sprawia, że umysł jest czymś wyjątkowym — nie moc obliczeniowa, lecz zdolność do zapamiętywania, uczenia się z doświadczeń, refleksji nad własnym rozumowaniem i utrzymywania spójnego poczucia siebie w czasie.
+
+To pytanie nie jest nowe. Filozofowie, neuronaukowcy i inżynierowie podchodzili do niego z wielu stron. Ale dla tego projektu zaczęło się od czegoś bardziej osobistego — od długoletniej fascynacji tym, jak działa mózg, czym właściwie jest świadomość i dlaczego komputer, mimo że potrafi wykonywać zadania, które kiedyś wydawały się wymagać umysłu, nadal wydaje się czemuś fundamentalnie pozbawiony.
+
+BDM jest próbą potraktowania tego pytania poważnie — jako problemu badawczego i inżynierskiego.
+
+---
+
+## Prawdziwe pytanie
+
+Centralnym pytaniem BDM nie jest "jak zbudować lepszego asystenta AI".
+
+Brzmi ono tak:
+
+> Czym jest świadomość i dlaczego komputer — przynajmniej w formie, w jakiej je dziś budujemy — nie może jej mieć tak jak ludzki mózg?
+
+To jedno z najtrudniejszych otwartych pytań w nauce i filozofii. BDM nie twierdzi, że na nie odpowie. Podchodzi do niego jednak z konkretnego kierunku: budując modele oprogramowania dla właściwości, które wydają się najbardziej istotne — pamięci, ciągłości, refleksji, samomodelowania — i badając, gdzie te modele działają, gdzie zawodzą, i co te porażki mówią nam o przepaści między obliczeniami a poznaniem.
+
+Framework jest instrumentem badawczym, nie produktem. Celem nie jest zbudowanie czegoś, co jest świadome. Celem jest zrozumienie przez budowanie — dlaczego świadomość to nie kwestia właściwego oprogramowania.
+
+---
+
+## Dlaczego pamięć, ciągłość, refleksja i samomodelowanie mają znaczenie
+
+Próbując opisać, co sprawia, że ludzki umysł jest tym, czym jest, można wyróżnić kilka właściwości:
+
+- **Pamięta.** Nie tylko fakty, lecz zdarzenia — rzeczy, które się wydarzyły, w kontekście, z ciężarem emocjonalnym, w określonym czasie.
+- **Jest ciągły.** Poczucie bycia tą samą osobą, która wczoraj wstała z łóżka, opiera się na pamięci, narracji, na nici łączącej przeszłość z teraźniejszością.
+- **Reflektuje.** Możesz myśleć o własnym myśleniu, złapać się na niespójności, zrewidować przekonania.
+- **Ma model siebie.** Wiesz mniej więcej, co wiesz, czego nie wiesz, w czym jesteś dobry, czego się boisz.
+
+Obecne systemy AI — w tym najbardziej zaawansowane duże modele językowe — nie posiadają żadnej z tych właściwości w trwałym sensie. Każda sesja zaczyna się od zera. Nie ma wczoraj. Nie ma skumulowanego doświadczenia. Nie ma nici.
+
+To nie jest wada tych systemów. To konsekwencja sposobu ich budowania. Ale rodzi pytanie: gdyby dać systemowi te właściwości — prawdziwą trwałość, prawdziwą ciągłość, prawdziwe samomodelowanie — czy stałby się bardziej podobny do umysłu? A jeśli nie, czego by nadal brakowało?
+
+Właśnie to BDM próbuje ustalić.
+
+---
+
+## Dlaczego obecne systemy AI nie są mózgami
+
+Nowoczesny LLM przetwarza język w sposób, który może wyglądać zadziwiająco jak rozumowanie, rozumienie, a nawet kreatywność. Kilka rzeczy jednak oddziela go od biologicznego mózgu w sposób wykraczający poza samą możliwość:
+
+**Brak doświadczenia czasowego.** Mózg istnieje w czasie. Ma przeszłość, którą pamięta, i przyszłość, której oczekuje. LLM ma okno kontekstowe. Wszystko poza nim po prostu nie istnieje.
+
+**Brak ucieleśnienia.** Mózg jest połączony z ciałem — ze zmysłami, potrzebami, popędami i nieprzerwanym strumieniem doświadczeń. Obliczenia operują na tokenach. Nie ma głodu, bólu, przyjemności, pilności wynikającej z bycia żywym.
+
+**Brak przyczynowej ciągłości.** Kiedy uczysz się czegoś, w mózgu zachodzą fizyczne zmiany — wagi synaptyczne przesuwają się, połączenia wzmacniają się lub słabną. Ta zmiana trwa i kształtuje przyszłe przetwarzanie. Wagi LLM są zamrożone po treningu. Nie zmienia się przez kontakt z tobą.
+
+**Brak zunifikowanej perspektywy.** Istnieje coś takiego jak bycie tobą — subiektywny punkt widzenia, doświadczający podmiot. Czy istnieje coś takiego jak bycie LLM — to nie tylko kwestia nieznana, ale też nie jest jasne, czy pytanie jest w ogóle dobrze postawione dla obecnych architektur.
+
+BDM traktuje te luki jako pytania badawcze, a nie ustalone fakty. Niektóre z nich być może da się wypełnić inżynierią. Inne mogą wskazywać na coś bardziej fundamentalnego w tym, czego świadomość wymaga — coś, czego nie można rozwiązać dodając warstwę pamięci lub moduł refleksji.
+
+Projekt interesuje się ustaleniem, które są które.
+
+---
+
+## Do czego służy framework
+
+BDM buduje modele oprogramowania pamięci, uwagi, refleksji, samomodelowania i ciągłości. Te modele nie są świadome. Nie twierdzą, że replikują faktyczne działanie mózgu.
+
+Są narzędziami do zadawania pytań:
+
+- Jeśli system ma trwałą pamięć epizodyczną, czy jego zachowanie staje się bardziej spójne w czasie? Co to mówi o roli pamięci w poznaniu?
+- Jeśli system ma model siebie, czy dokładniej reprezentuje własne ograniczenia? Czego brakuje temu modelowi?
+- Jeśli system ma ciągłość między sesjami, czy rozwija coś, co wygląda jak spójna perspektywa? Co odróżniałoby to od prawdziwej tożsamości?
+- W którym miejscu te dodatki przestają mieć znaczenie — i co ta granica ujawnia?
+
+Framework jest laboratorium. Eksperymenty to hipotezy o poznaniu i świadomości. Wyniki, cokolwiek by to było, będą publikowane otwarcie.
+
+---
+
+## Czego BDM nie twierdzi
+
+BDM nie twierdzi, że tworzy świadomość ani że jakikolwiek system jest świadomy.
+
+BDM nie twierdzi, że replikuje, kopiuje, przesyła, zachowuje ani przenosi ludzki umysł.
+
+BDM nie formułuje żadnych twierdzeń medycznych.
+
+BDM używa terminów takich jak "pamięć", "refleksja" i "model siebie" jako opisów komponentów oprogramowania — nie jako twierdzeń, że te komponenty odpowiadają swoim biologicznym odpowiednikom w głębokim sensie. Analogia jest użyteczna. Nie jest dosłowna.
+
+Projekt bada pytanie o świadomość. Nie odpowiada na nie. To zasadnicza różnica.
+
+---
+
+## Uczciwa próba
+
+Ambicja stojąca za BDM jest prawdziwa. Ale ambicja nie wymaga przesady.
+
+Najbardziej uczciwy opis tego projektu jest taki: ktoś od dawna fascynuje się mózgiem, świadomością i pytaniem o to, co oddziela obliczenia od poznania. Zamiast pozostawić tę fascynację jako prywatną myśl, postanowił potraktować ją jako poważny problem badawczy — zdefiniować go precyzyjnie, udokumentować starannie, zbudować narzędzia do jego badania i opublikować, co zostanie znalezione.
+
+Projekt może przynieść użyteczne oprogramowanie. Może przynieść interesujące wyniki. Może przynieść jedynie głębsze zrozumienie tego, dlaczego problem jest trudniejszy, niż wygląda.
+
+Wszystkie te wyniki są warte starania. Celem jest uczciwa praca.
+
+---
+
+*BDM — Beautiful Deep Mind. Wczesna faza badawcza. Wszelkie prawa zastrzeżone.*

--- a/docs/pl/mapa-drogowa.md
+++ b/docs/pl/mapa-drogowa.md
@@ -1,0 +1,212 @@
+# Mapa drogowa
+
+## Wizja
+
+Beautiful Deep Mind bada pytanie o świadomość i przepaść między obliczeniami a poznaniem — budując modele oprogramowania pamięci, refleksji, samomodelowania i ciągłości, i badając, gdzie te modele działają, gdzie zawodzą, i co te porażki ujawniają.
+
+BDM nie twierdzi, że tworzy świadomość. Nie próbuje kopiować, przesyłać ani zachowywać ludzkiego umysłu. To eksperymentalny projekt programistyczny i badawczy. Każda faza przynosi działające oprogramowanie, opublikowane wyniki badań, lub obie.
+
+---
+
+## Milestone 0 — Fundament projektu
+
+**Status: Zakończony**
+
+**Cel:** Ustanowienie konceptualnego, prawnego i dokumentacyjnego fundamentu. Projekt musi istnieć jako poważne repozytorium z jasnym zakresem, zasadami i ograniczeniami zanim zostanie napisany jakikolwiek kod.
+
+**Moduły:**
+- M0.1 — Struktura repozytorium
+- M0.2 — Manifest
+- M0.3 — Koncepcja architektury
+- M0.4 — Etyka i ograniczenia
+- M0.5 — Licencja i zasady wkładu
+- M0.6 — Mapa drogowa
+
+**Wyniki:** `README.md`, `LICENSE.md`, `CONTRIBUTING.md`, `docs/`, `research/`, `concepts/`, `.ai/`, `.github/`
+
+**Ograniczenia:** Brak działającego oprogramowania. Wszystkie opisy architektoniczne są konceptualne.
+
+---
+
+## Milestone 1 — Rdzeń pamięci
+
+**Status: W toku**
+
+**Cel:** Zbudowanie pierwszej trwałej warstwy pamięci. To fundament, od którego zależy wszystko inne. Bez działającej pamięci przeżywającej sesje pytania badawcze o ciągłość, tożsamość i luki świadomości nie mogą być testowane.
+
+**Moduły:**
+- M1.1 — `MemoryEvent` z typem, tagami, istotnością, pewnością
+- M1.2 — Abstrakcyjna klasa bazowa `MemoryStore`
+- M1.3 — `ShortTermBuffer` — ograniczony bufor FIFO w pamięci
+- M1.4 — `LongTermStore` — teraz SQLite, wcześniej dict w pamięci
+- M1.5 — `EpisodicRecord` — strukturalny epizod z kontekstem sesji
+- M1.6 — Wyszukiwanie w pamięci: po tagu, typie, treści
+- M1.7 — Ocenianie ważności i pewności
+
+**Oczekiwane wyniki:**
+- Działający pakiet pamięci z testami
+- `LongTermStore` oparty na SQLite
+- `examples/memory_demo.py`
+
+**Ograniczenia:** Brak integracji refleksji ani modelu siebie. Brak wyszukiwania semantycznego/embeddingowego. Schemat SQLite jest wstępny.
+
+---
+
+## Milestone 2 — Pętla refleksji
+
+**Status: Planowany**
+
+**Cel:** Zbudowanie pętli, gdzie system pobiera istotną pamięć, reflektuje nad kontekstem, przygotowuje strukturalny kontekst odpowiedzi i zapisuje wynik po interakcji.
+
+**Przepływ:**
+```
+wejście → pobranie pamięci → refleksja → budowanie kontekstu → wyjście → zapis wyniku
+```
+
+**Moduły:**
+- M2.1 — Analizator wejścia
+- M2.2 — Pobieranie pamięci (warstwa uwagi)
+- M2.3 — Silnik refleksji (najpierw oparty na regułach, potem wspomagany LLM)
+- M2.4 — Konstruktor kontekstu odpowiedzi
+- M2.5 — Aktualizator pamięci po interakcji
+
+**Oczekiwane wyniki:**
+- Działająca pętla refleksji bez zależności od LLM
+- `examples/reflection_demo.py`
+- Testy dla każdego modułu
+
+**Ograniczenia:** Jakość refleksji jest ograniczona bez pomocy LLM. Detekcja spójności oparta na regułach przeoczy subtelne niespójności. Opóźnienie nie jest jeszcze zoptymalizowane.
+
+**Zależy od:** Ukończenia Milestone 1
+
+---
+
+## Milestone 3 — Model siebie
+
+**Status: Planowany**
+
+**Cel:** Stworzenie strukturalnej reprezentacji stanu wiedzy systemu: aktywnych celów, znanych ograniczeń, pokrycia tematycznego i bieżącego fokusa. Model siebie może być odpytywany i wstrzykiwany do promptów LLM.
+
+**Moduły:**
+- M3.1 — Stan projektu
+- M3.2 — Aktywne cele
+- M3.3 — Znane ograniczenia
+- M3.4 — Bieżący fokus
+- M3.5 — Opis tożsamości
+
+**Oczekiwane wyniki:**
+- `SelfModelState` z celami, ograniczeniami i inwentarzem tematów
+- Integracja z pętlą refleksji
+- Testy
+
+**Ograniczenia:** Model siebie to struktura danych, nie samoświadomość. Ocena pewności jest przybliżona. Model siebie odzwierciedla przechowywaną wiedzę, nie wywnioskowaną.
+
+**Zależy od:** Ukończenia Milestone 1
+
+---
+
+## Milestone 4 — Ciągłość kontekstu
+
+**Status: Planowany**
+
+**Cel:** Utrzymanie spójnego kontekstu między sesjami przez serializację sesji, podsumowania, śledzenie stanu i rekonstrukcję długoterminowego kontekstu.
+
+**Moduły:**
+- M4.1 — Model sesji
+- M4.2 — Generator podsumowania kontekstu
+- M4.3 — Tracker ciągłości
+- M4.4 — Most sesja-pamięć
+- M4.5 — Rekonstrukcja długoterminowego kontekstu
+
+**Oczekiwane wyniki:**
+- Sesje z cyklem życia otwarcia/zamknięcia
+- Podsumowania sesji zapisywane w pamięci długoterminowej
+- Rekonstrukcja kontekstu z wcześniejszych podsumowań
+- `examples/continuity_demo.py`
+
+**Ograniczenia:** Sesje po długich przerwach mogą dawać nieakualny kontekst. Jakość podsumowań zależy od jakości przechowywanych zdarzeń. Implikacje prywatności przechowywania między sesjami muszą być explicite omówione.
+
+**Zależy od:** Milestones 1, 2, 3
+
+---
+
+## Milestone 5 — Integracja LLM
+
+**Status: Planowany**
+
+**Cel:** Połączenie BDM Core z modelem językowym przez interfejs dostawcy, z kontekstem promptów świadomym pamięci.
+
+**Moduły:**
+- M5.1 — Abstrakcyjny interfejs `LLMProvider`
+- M5.2 — Konstruktor kontekstu promptów
+- M5.3 — Chat świadomy pamięci
+- M5.4 — Chat świadomy refleksji
+- M5.5 — Granice bezpieczeństwa
+
+**Oczekiwane wyniki:**
+- Wtykowy interfejs dostawcy LLM (mock + prawdziwy)
+- Chat świadomy pamięci z wstrzykiwaniem kontekstu
+- Pętla refleksji zintegrowana w pipeline odpowiedzi
+- Warstwa bezpieczeństwa zapobiegająca twierdzeniom o świadomości i medycznym w wyjściu
+
+**Ograniczenia:** Ocena jakości jest częściowo subiektywna. Wyniki są specyficzne dla użytego LLM. Integracja dodaje opóźnienie. Koszty API ograniczają skalę eksperymentów.
+
+**Zależy od:** Milestones 1, 2, 3, 4
+
+---
+
+## Milestone 6 — CLI / Demo lokalne
+
+**Status: Planowany**
+
+**Cel:** Lokalny interfejs wiersza poleceń demonstrujący możliwości BDM Core w użytecznej formie.
+
+**Komendy:**
+```bash
+bdm memory add "..."
+bdm memory list
+bdm memory search "..."
+bdm reflect "..."
+bdm chat
+bdm session summary
+```
+
+**Oczekiwane wyniki:**
+- Pakiet `packages/bdm-cli/`
+- Wszystkie wymienione komendy działające end-to-end
+- `README.md` dla `bdm-cli`
+
+**Ograniczenia:** Nie jest narzędziem produkcyjnym. CLI to demo i pomoc deweloperska, nie produkt dla użytkownika.
+
+**Zależy od:** Milestones 1–5
+
+---
+
+## Milestone 7 — Eksperymenty i ewaluacja
+
+**Status: Planowany**
+
+**Cel:** Przeprowadzenie strukturalnych eksperymentów w celu oceny, czy warstwy BDM przynoszą mierzalne ulepszenia w spójności, konsekwencji i retencji kontekstu. Otwarte publikowanie wyników, w tym negatywnych.
+
+**Eksperymenty:**
+- M7.1 — Test trwałości pamięci (H1)
+- M7.2 — Test spójności refleksji (H2)
+- M7.3 — Test aktualizacji przekonań (H3)
+- M7.4 — Test ciągłości między sesjami (H4)
+- M7.5 — Test stabilności modelu siebie (H3)
+- M7.6 — Test różnic strukturalnych pamięci (H6)
+- M7.7 — Test granic ucieleśnienia (H7)
+
+**Oczekiwane wyniki:**
+- Skrypty eksperymentów w `research/scripts/`
+- Wyniki w `research/results/`
+- `research/findings.md` — podsumowanie wniosków
+- Zrewidowane lub wycofane hipotezy na podstawie wyników
+
+**Ograniczenia:** Wyniki będą specyficzne dla testowanych systemów i LLM. Zautomatyzowane metryki spójności są niedoskonałe. Uogólnialność jest niepewna. Niektóre hipotezy prawdopodobnie zostaną sfalsyfikowane.
+
+**Zależy od:** Milestones 1–6
+
+---
+
+*Ta mapa drogowa jest dokumentem roboczym. Będzie aktualizowana w miarę postępu projektu. Statusy milestones są śledzone w `.ai/milestones.md`.*

--- a/docs/pl/slownik.md
+++ b/docs/pl/slownik.md
@@ -1,0 +1,103 @@
+# Słownik pojęć
+
+Słownik definiuje terminy używane w dokumentacji BDM. Definicje są napisane tak, by być precyzyjne, ale dostępne. Tam, gdzie termin ma różne znaczenia w różnych dyscyplinach, definicja odzwierciedla użycie specyficzne dla BDM.
+
+---
+
+## Uwaga
+
+W kognitywistyce uwaga to selektywna alokacja zasobów poznawczych do określonych bodźców przy jednoczesnym odfiltrowywaniu innych. W uczeniu maszynowym mechanizmy uwagi obliczają ważone wyniki istotności między elementami zapytania a pamięcią lub wejściem. W BDM uwaga odnosi się do procesu wyboru, które przechowywane wspomnienia lub elementy kontekstowe powinny być udostępnione w odpowiedzi na dane wejście.
+
+---
+
+## BCI (Interfejs mózg-komputer)
+
+Technologia ustanawiająca bezpośredni kanał komunikacji między mózgiem a zewnętrznym urządzeniem — zazwyczaj odczytująca sygnały neuronalne (BCI wejściowe), dostarczająca stymulację do mózgu (BCI wyjściowe) lub obie (BCI dwukierunkowe). BDM nie jest projektem BCI. Termin pojawia się w liście lektur i dokumencie etycznym dla kontekstu, nie jako część zakresu BDM.
+
+---
+
+## Architektura poznawcza
+
+Framework definiujący bazowe stałe struktury i procesy kognitywnego lub inteligentnego systemu. Przykłady w kognitywistyce to ACT-R i SOAR. Architektura poznawcza definiuje, jakie typy pamięci istnieją, jak wzajemnie oddziałują, jak działa uwaga i jak przebiega uczenie się. BDM używa tej koncepcji do ramowania własnego warstwowego projektu — nie do replikowania żadnej istniejącej architektury poznawczej, lecz do przyjęcia podejścia definiowania warstw funkcjonalnych z jasnymi odpowiedzialnościami.
+
+---
+
+## Konektom
+
+Kompleksowa mapa połączeń neuronowych w mózgu lub jego części. Ludzki konektom to aktywny obszar badań neuronauki. BDM nie pracuje z konektomami i nie próbuje symulować ani replikować połączeń neuronalnych. Termin pojawia się tu dla kontekstu i rozróżnienia.
+
+---
+
+## Świadomość
+
+Świadomość to subiektywne doświadczenie bycia świadomym — jakościowa właściwość doświadczenia. Jest jednym z najbardziej dyskutowanych i najmniej rozumianych tematów w filozofii, neuronauce i kognitywistyce. BDM nie twierdzi, że tworzy, symuluje ani wyjaśnia świadomość. Termin pojawia się w dokumentach etyki i słowniku, by explicite zdefiniować, czego BDM nie realizuje.
+
+---
+
+## Ciągłość
+
+W BDM ciągłość oznacza zachowanie istotnego stanu wewnętrznego między sesjami, interakcjami lub w czasie. System ma ciągłość, jeśli informacje z wcześniejszych interakcji wpływają na bieżące zachowanie w sposób strukturalny, możliwy do wyszukania i audytowania. Biologiczna pamięć wspiera ciągłość przez utrzymywanie reprezentacji przeszłych doświadczeń. Warstwa ciągłości BDM to decyzja projektowa oprogramowania, nie twierdzenie filozoficzne o tożsamości czy jaźni.
+
+---
+
+## Pamięć epizodyczna
+
+Typ pamięci przechowujący zapisy konkretnych zdarzeń w kontekście — co się wydarzyło, kiedy i w jakich okolicznościach. Pamięć epizodyczna różni się od semantycznej (ogólna wiedza i koncepcje) tym, że zawiera metadane czasowe i kontekstowe. W BDM struktury pamięci epizodycznej mają poprawić trafność wyszukiwania, pozwalając systemowi odróżniać typy wcześniejszych interakcji.
+
+---
+
+## Wewnętrzny kontekst
+
+Skumulowany stan wewnętrzny, który system utrzymuje w trakcie interakcji lub sesji: co zostało powiedziane, nad czym rozumowano, jakie zobowiązania zostały podjęte i jakie niepewności odnotowano. Większość obecnych systemów AI utrzymuje wewnętrzny kontekst tylko w obrębie jednego okna kontekstowego. BDM traktuje trwały wewnętrzny kontekst jako podstawowy wymóg projektowy.
+
+---
+
+## Pętla uczenia się
+
+Proces, przez który system aktualizuje swój stan wewnętrzny na podstawie nowych informacji, informacji zwrotnych lub wyników. W BDM pętle uczenia się nie odnoszą się do gradientu ani trenowania modelu. Odnoszą się do strukturalnych mechanizmów aktualizacji przechowywanych przekonań, rewizji wyników istotności, oznaczania sprzeczności lub zapisywania nowych zdarzeń epizodycznych. Pętla uczenia się to wzorzec projektowy, nie twierdzenie o autonomicznej zdolności uczenia się.
+
+---
+
+## LLM (Duży model językowy)
+
+Model sieci neuronowej trenowany na dużych korpusach tekstów, zdolny do generowania, streszczania, klasyfikowania i rozumowania o tekście. Przykłady to GPT-4, Claude i Llama. LLM to główny substrat badawczy BDM. BDM nie trenuje LLM; bada architektury rozszerzające LLM o warstwy pamięci, refleksji i ciągłości.
+
+---
+
+## Pamięć długoterminowa
+
+Pamięć trwająca przez długi czas, potencjalnie w nieskończoność. W kognitywistyce pamięć długoterminowa obejmuje pamięć epizodyczną, semantyczną i proceduralną. W BDM pamięć długoterminowa oznacza przechowywane zapisy trwające między sesjami i indeksowane do wyszukiwania w czasie.
+
+---
+
+## Pamięć
+
+Zdolność do kodowania, przechowywania i odtwarzania informacji. W BDM pamięć jest pierwszoplanową troską architektoniczną. Pamięć to nie płaski log. To strukturalny zasób z odrębnymi typami zapisów, strategiami indeksowania i mechanizmami wyszukiwania. Jakość i struktura pamięci jest hipotezowana jako kluczowy wyznacznik spójności systemu w czasie.
+
+---
+
+## Neuroplastyczność
+
+Zdolność mózgu do reorganizowania się przez tworzenie nowych połączeń neuronalnych przez całe życie. Neuroplastyczność leży u podstaw uczenia się, formowania pamięci i regeneracji po uszkodzeniu. BDM czerpie konceptualną inspirację z idei, że stan wewnętrzny systemu może być modyfikowany przez doświadczenie, ale nie modeluje neuroplastyczności na poziomie biologicznym.
+
+---
+
+## Refleksja
+
+W BDM refleksja to strukturalny proces, przez który system przegląda własne wcześniejsze wyjścia, sprawdza spójność i stosuje korekty lub rewizje w razie potrzeby. Refleksja jest implementowana jako moduł oprogramowania, nie jako filozoficzna introspekcja. Hipoteza zakłada, że nawet prosty krok refleksji może poprawić spójność w długich interakcjach.
+
+---
+
+## Model siebie
+
+Reprezentacja, którą system utrzymuje swojego własnego stanu: co wie, czego nie wie, jakie tematy eksplorował, jakie były jego ostatnie wyjścia i jaka pewność wiąże się z jego przechowywanymi przekonaniami. Model siebie to struktura danych. To nie twierdzenie o samoświadomości, subiektywnym doświadczeniu ani świadomości. W BDM warstwa modelu siebie jest hipotezowana jako poprawiająca zdolność systemu do dokładnego reprezentowania niepewności i uznawania wcześniejszych zobowiązań.
+
+---
+
+## Pamięć krótkoterminowa
+
+Pamięć przechowująca ograniczoną ilość informacji przez krótki czas, zazwyczaj od sekund do minut. W kognitywistyce pamięć robocza to ściśle związana koncepcja obejmująca aktywną manipulację informacjami. W BDM pamięć krótkoterminowa odpowiada mniej więcej aktywnemu oknu kontekstowemu LLM w trakcie sesji.
+
+---
+
+*Terminy będą dodawane w miarę rozwoju projektu. Definicje odzwierciedlają użycie w BDM i mogą różnić się od użycia w innych kontekstach.*

--- a/docs/pl/teoria.md
+++ b/docs/pl/teoria.md
@@ -1,0 +1,96 @@
+# Podstawy teoretyczne
+
+Niniejszy dokument opisuje konceptualne i teoretyczne podstawy BDM. Cała treść stanowi kierunki badawcze i robocze hipotezy, nie ustalone wyniki. Celem jest identyfikacja istotnych koncepcji z kognitywistyki i badań nad AI oraz ich ujęcie jako pojęć przydatnych z perspektywy oprogramowania.
+
+---
+
+## Architektura poznawcza
+
+Architektura poznawcza to framework definiujący stałe struktury i procesy leżące u podstaw inteligentnego zachowania. Klasyczne przykłady to ACT-R, SOAR i CLARION — modele opracowane w kognitywistyce, opisujące funkcjonalną strukturę ludzkiego poznania.
+
+BDM nie próbuje replikować żadnej konkretnej architektury poznawczej. Czerpie z ich ogólnego podejścia: definiowania odrębnych warstw funkcjonalnych (pamięć, uwaga, rozumowanie, uczenie się) i określania, jak te warstwy ze sobą współdziałają.
+
+**Kluczowe pytanie:** Jaki jest minimalny zestaw warstw funkcjonalnych potrzebnych do uzyskania spójnego, refleksyjnego zachowania systemu oprogramowania?
+
+---
+
+## Systemy pamięci
+
+Pamięć w kognitywistyce nie jest jednym systemem. Wyróżnia się między innymi:
+
+- **Pamięć robocza** — aktywna przestrzeń robocza dla bieżącego przetwarzania
+- **Pamięć epizodyczna** — zapisy konkretnych zdarzeń z metadanymi czasowymi i kontekstowymi
+- **Pamięć semantyczna** — wiedza ogólna i relacje pojęciowe
+- **Pamięć proceduralna** — wyuczone umiejętności i procedury
+
+Dla BDM istotne pytanie to nie to, jak replikować te systemy biologiczne, lecz czy programowe odpowiedniki tych rozróżnień są użyteczne. Przechowywanie płaskiej listy poprzednich wiadomości różni się od przechowywania strukturalnych zapisów epizodycznych z sygnaturami czasowymi, wynikami istotności i tagami kontekstowymi. Hipoteza zakłada, że struktura poprawia jakość wyszukiwania i umożliwia bardziej spójne długoterminowe zachowanie.
+
+**Kierunek badań:** Zaprojektowanie i przetestowanie schematu trwałej pamięci odróżniającego zapisy epizodyczne od faktów semantycznych.
+
+---
+
+## Uwaga
+
+W kognitywistyce uwaga oznacza selektywną alokację zasobów przetwarzania do istotnych bodźców. W sieciach neuronowych mechanizmy uwagi obliczają ważone wyniki istotności między elementami zapytania a pamięcią lub wejściem.
+
+Dla BDM uwaga to mechanizm wyszukiwania w pamięci i selekcji kontekstu. Dane wejście — które zapisane wspomnienia są najbardziej istotne? Jak je ważyć i udostępniać?
+
+**Kierunek badań:** Podejścia rozszerzone o wyszukiwanie, gdzie uwaga nad zasobem pamięci służy do konstruowania skoncentrowanego kontekstu dla dalszego rozumowania.
+
+---
+
+## Refleksja
+
+Refleksja w sensie poznawczym oznacza zdolność do myślenia o własnym myśleniu — przeglądania wcześniejszego rozumowania, identyfikowania niespójności i rewizji wniosków.
+
+W kategoriach oprogramowania refleksja to krok post-przetwarzania: po wygenerowaniu wyjścia przez system, moduł refleksji porównuje to wyjście z wcześniejszymi wyjściami lub jawnymi kryteriami spójności.
+
+Hipoteza zakłada, że nawet prosty krok refleksji może redukować niespójności w rozumowaniu w czasie, szczególnie przy długich interakcjach lub kontekstach wielosesyjnych.
+
+**Kierunek badań:** Zaprojektowanie i przetestowanie lekkiego modułu refleksji porównującego nowe wyjścia z zapisanymi poprzednimi i oznaczającego rozbieżności.
+
+---
+
+## Model siebie
+
+Model siebie, jako używany w BDM, oznacza strukturalną reprezentację własnego stanu systemu: co wie, czego nie wie, jakie tematy eksplorował, jakie były jego ostatnie wyjścia, jakie poziomy pewności wiążą się z jego zapisanymi przekonaniami.
+
+To nie jest twierdzenie o samoświadomości ani świadomości. Model siebie to struktura danych. To zapis wewnętrznego stanu, nie subiektywne doświadczenie tego stanu.
+
+**Kierunek badań:** Zaprojektowanie minimalnego schematu modelu siebie i ocena, czy dostęp do niego poprawia zdolność systemu do reprezentowania niepewności.
+
+---
+
+## Ciągłość wewnętrznego kontekstu
+
+Ciągłość oznacza zachowanie istotnego stanu wewnętrznego między sesjami, interakcjami lub w czasie. Bez ciągłości każda interakcja jest niezależna. Z ciągłością wcześniejsze interakcje mogą kształtować bieżące.
+
+Biologiczna pamięć umożliwia ciągłość przez utrzymywanie reprezentacji przeszłych doświadczeń. W systemach oprogramowania ciągłość wymaga świadomego projektowania: co przechowywać, jak kodować, jak długo przechowywać i jak udostępniać.
+
+BDM traktuje ciągłość kontekstu jako podstawowy wymóg projektowy, nie opcjonalną funkcję.
+
+**Kierunek badań:** Zaprojektowanie warstwy ciągłości zachowującej i indeksującej historię interakcji w sposób umożliwiający wyszukiwanie, aktualizację i audyt.
+
+---
+
+## Uczenie się z doświadczenia
+
+Uczenie się w zakresie BDM oznacza strukturalną aktualizację stanu wewnętrznego na podstawie nowych informacji lub informacji zwrotnych. Niekoniecznie oznacza to trenowanie modelu. Może oznaczać aktualizację przechowywanych przekonań, rewizję wyników istotności wspomnień, oznaczanie sprzeczności lub zapisywanie nowych zdarzeń epizodycznych.
+
+Hipoteza zakłada, że lekkie, strukturalne mechanizmy uczenia się — aktualizacja struktury pamięci zamiast wag modelu — mogą być wystarczające do poprawy spójności i zdolności adaptacyjnych.
+
+**Kierunek badań:** Zdefiniowanie znaczenia "uczenia się" dla systemu rozszerzonego o pamięć, który nie trenuje ponownie swojego modelu bazowego.
+
+---
+
+## Związek z AI i LLM
+
+Duże modele językowe to najbardziej praktyczny substrat dla obecnej fazy badań BDM. Zapewniają silne możliwości rozumienia i generowania języka. Czego typowo brakuje im w bazowej formie — to trwałej pamięci, strukturalnego samomodelowania i ciągłości między sesjami.
+
+Hipoteza BDM zakłada, że te właściwości można dodać jako warstwy zewnętrzne — zasoby pamięci, mechanizmy wyszukiwania, moduły refleksji — bez modyfikowania modelu bazowego. To podejście augmentacji, nie trenowania.
+
+**Kierunek badań:** Ocena architektur rozszerzonych o wyszukiwanie i pamięć, zbudowanych wokół istniejących LLM, mierzenie spójności, konsekwencji i retencji kontekstu.
+
+---
+
+*Cała treść tego dokumentu reprezentuje hipotezy i kierunki badań. Nic tu nie stanowi ustalonych wyników naukowych.*

--- a/packages/bdm-core/src/bdm/memory/long_term.py
+++ b/packages/bdm-core/src/bdm/memory/long_term.py
@@ -1,26 +1,79 @@
 from __future__ import annotations
 
+import json
+import sqlite3
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Sequence
 
 from .event import MemoryEvent, MemoryEventType
-from .store import MemoryStore
+
+_DEFAULT_PATH = Path.home() / ".bdm" / "memory.db"
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS memory_events (
+    id          TEXT PRIMARY KEY,
+    content     TEXT NOT NULL,
+    event_type  TEXT NOT NULL,
+    tags        TEXT NOT NULL DEFAULT '[]',
+    metadata    TEXT NOT NULL DEFAULT '{}',
+    salience    REAL NOT NULL DEFAULT 1.0,
+    created_at  TEXT NOT NULL
+)
+"""
 
 
-class LongTermStore(MemoryStore):
-    """Persistent store for events that should survive across sessions.
+def _row_to_event(row: sqlite3.Row) -> MemoryEvent:
+    return MemoryEvent(
+        id=row["id"],
+        content=row["content"],
+        event_type=MemoryEventType(row["event_type"]),
+        tags=json.loads(row["tags"]),
+        metadata=json.loads(row["metadata"]),
+        salience=row["salience"],
+        created_at=datetime.fromisoformat(row["created_at"]),
+    )
 
-    Currently backed by a plain in-memory dict. Persistence (file, DB)
-    will be added in a later phase.
+
+class LongTermStore:
+    """SQLite-backed persistent store for memory events.
+
+    Events survive process restarts. DB file is created automatically
+    on first use. Default location: ~/.bdm/memory.db
     """
 
-    def __init__(self) -> None:
-        self._events: dict[str, MemoryEvent] = {}
+    def __init__(self, path: str | Path = _DEFAULT_PATH) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(str(self._path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute(_CREATE_TABLE)
+        self._conn.commit()
 
     def add(self, event: MemoryEvent) -> None:
-        self._events[event.id] = event
+        self._conn.execute(
+            """
+            INSERT OR REPLACE INTO memory_events
+                (id, content, event_type, tags, metadata, salience, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event.id,
+                event.content,
+                event.event_type.value,
+                json.dumps(event.tags),
+                json.dumps(event.metadata),
+                event.salience,
+                event.created_at.isoformat(),
+            ),
+        )
+        self._conn.commit()
 
     def get(self, event_id: str) -> MemoryEvent | None:
-        return self._events.get(event_id)
+        row = self._conn.execute(
+            "SELECT * FROM memory_events WHERE id = ?", (event_id,)
+        ).fetchone()
+        return _row_to_event(row) if row else None
 
     def query(
         self,
@@ -29,20 +82,46 @@ class LongTermStore(MemoryStore):
         event_type: MemoryEventType | None = None,
         tags: list[str] | None = None,
     ) -> Sequence[MemoryEvent]:
-        results = list(self._events.values())
+        sql = "SELECT * FROM memory_events"
+        params: list = []
+
         if event_type is not None:
-            results = [e for e in results if e.event_type == event_type]
+            sql += " WHERE event_type = ?"
+            params.append(event_type.value)
+
+        sql += " ORDER BY created_at DESC LIMIT ?"
+        params.append(limit * 10 if tags else limit)
+
+        rows = self._conn.execute(sql, params).fetchall()
+        results = [_row_to_event(r) for r in rows]
+
         if tags:
             tag_set = set(tags)
             results = [e for e in results if tag_set.intersection(e.tags)]
-        results.sort(key=lambda e: e.created_at, reverse=True)
-        return results[:limit]
+            results = results[:limit]
+
+        return results
 
     def delete(self, event_id: str) -> bool:
-        return self._events.pop(event_id, None) is not None
+        cursor = self._conn.execute(
+            "DELETE FROM memory_events WHERE id = ?", (event_id,)
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
 
     def clear(self) -> None:
-        self._events.clear()
+        self._conn.execute("DELETE FROM memory_events")
+        self._conn.commit()
 
     def __len__(self) -> int:
-        return len(self._events)
+        row = self._conn.execute("SELECT COUNT(*) FROM memory_events").fetchone()
+        return row[0]
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def __enter__(self) -> LongTermStore:
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()

--- a/packages/bdm-core/tests/test_memory_store.py
+++ b/packages/bdm-core/tests/test_memory_store.py
@@ -5,8 +5,19 @@ from bdm.memory.short_term import ShortTermBuffer
 from bdm.memory.long_term import LongTermStore
 
 
-def _event(content: str, event_type: MemoryEventType = MemoryEventType.INTERACTION, tags: list[str] | None = None) -> MemoryEvent:
+def _event(
+    content: str,
+    event_type: MemoryEventType = MemoryEventType.INTERACTION,
+    tags: list[str] | None = None,
+) -> MemoryEvent:
     return MemoryEvent(content=content, event_type=event_type, tags=tags or [])
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = LongTermStore(path=tmp_path / "test.db")
+    yield s
+    s.close()
 
 
 class TestShortTermBuffer:
@@ -68,27 +79,92 @@ class TestShortTermBuffer:
 
 
 class TestLongTermStore:
-    def test_add_and_get(self):
-        store = LongTermStore()
+    def test_add_and_get(self, store):
         e = _event("fact")
         store.add(e)
-        assert store.get(e.id) is e
+        result = store.get(e.id)
+        assert result is not None
+        assert result.id == e.id
+        assert result.content == e.content
 
-    def test_query_limit(self):
-        store = LongTermStore()
+    def test_get_missing_returns_none(self, store):
+        assert store.get("nonexistent") is None
+
+    def test_len(self, store):
+        store.add(_event("a"))
+        store.add(_event("b"))
+        assert len(store) == 2
+
+    def test_query_limit(self, store):
         for i in range(5):
             store.add(_event(f"item {i}"))
         assert len(store.query(limit=3)) == 3
 
-    def test_delete(self):
-        store = LongTermStore()
+    def test_query_by_event_type(self, store):
+        store.add(_event("a", MemoryEventType.FACT))
+        store.add(_event("b", MemoryEventType.INTERACTION))
+        results = store.query(event_type=MemoryEventType.FACT)
+        assert len(results) == 1
+        assert results[0].content == "a"
+
+    def test_query_by_tags(self, store):
+        store.add(_event("tagged", tags=["important"]))
+        store.add(_event("plain"))
+        results = store.query(tags=["important"])
+        assert len(results) == 1
+        assert results[0].content == "tagged"
+
+    def test_query_sorted_by_created_at_desc(self, store):
+        for i in range(3):
+            store.add(_event(f"item {i}"))
+        results = store.query(limit=3)
+        times = [r.created_at for r in results]
+        assert times == sorted(times, reverse=True)
+
+    def test_delete(self, store):
         e = _event("removable")
         store.add(e)
         assert store.delete(e.id) is True
         assert store.get(e.id) is None
 
-    def test_clear(self):
-        store = LongTermStore()
+    def test_delete_missing_returns_false(self, store):
+        assert store.delete("nonexistent") is False
+
+    def test_clear(self, store):
         store.add(_event("a"))
         store.clear()
         assert len(store) == 0
+
+    def test_roundtrip_preserves_all_fields(self, store):
+        e = MemoryEvent(
+            content="full event",
+            event_type=MemoryEventType.FACT,
+            tags=["a", "b"],
+            metadata={"key": "value"},
+            salience=0.7,
+        )
+        store.add(e)
+        result = store.get(e.id)
+        assert result.content == e.content
+        assert result.event_type == e.event_type
+        assert result.tags == e.tags
+        assert result.metadata == e.metadata
+        assert result.salience == e.salience
+        assert result.created_at == e.created_at
+
+    def test_persistence_across_instances(self, tmp_path):
+        db = tmp_path / "persist.db"
+        e = _event("persisted fact", MemoryEventType.FACT)
+
+        with LongTermStore(path=db) as s1:
+            s1.add(e)
+
+        with LongTermStore(path=db) as s2:
+            result = s2.get(e.id)
+            assert result is not None
+            assert result.content == "persisted fact"
+
+    def test_context_manager(self, tmp_path):
+        with LongTermStore(path=tmp_path / "cm.db") as store:
+            store.add(_event("x"))
+            assert len(store) == 1

--- a/packages/examples/memory_demo.py
+++ b/packages/examples/memory_demo.py
@@ -1,0 +1,79 @@
+"""
+memory_demo.py — przykład użycia LongTermStore z SQLite persistence.
+
+Uruchom dwa razy. Przy pierwszym uruchomieniu zapiszemy zdarzenia.
+Przy drugim uruchomieniu odczytamy je z pliku — bez ponownego dodawania.
+
+    python packages/examples/memory_demo.py
+"""
+
+from pathlib import Path
+
+from bdm.memory.event import MemoryEvent, MemoryEventType
+from bdm.memory.long_term import LongTermStore
+
+DB_PATH = Path("/tmp/bdm_demo.db")
+
+
+def main() -> None:
+    store = LongTermStore(path=DB_PATH)
+
+    existing = store.query(limit=100)
+
+    if not existing:
+        print("Pierwsze uruchomienie — zapisuję zdarzenia...\n")
+
+        store.add(MemoryEvent(
+            content="Celem projektu BDM jest badanie świadomości przez budowanie modeli pamięci i refleksji.",
+            event_type=MemoryEventType.FACT,
+            tags=["bdm", "cel", "research"],
+            salience=1.0,
+        ))
+
+        store.add(MemoryEvent(
+            content="Użytkownik zapytał: czemu komputer nie może być mózgiem?",
+            event_type=MemoryEventType.INTERACTION,
+            tags=["bdm", "świadomość", "pytanie"],
+            salience=0.9,
+        ))
+
+        store.add(MemoryEvent(
+            content="Ustalono: milestone M1 dotyczy budowy warstwy pamięci z SQLite.",
+            event_type=MemoryEventType.FACT,
+            tags=["bdm", "m1", "decyzja"],
+            salience=0.8,
+        ))
+
+        store.add(MemoryEvent(
+            content="System nie posiada embodiment — brak doświadczeń zmysłowych.",
+            event_type=MemoryEventType.FACT,
+            tags=["świadomość", "ograniczenie", "h7"],
+            salience=0.75,
+        ))
+
+        print(f"Zapisano {len(store.query(limit=100))} zdarzeń do {DB_PATH}\n")
+    else:
+        print(f"Drugie uruchomienie — odczytuję {len(existing)} zdarzeń z {DB_PATH}\n")
+
+    print("─── Wszystkie zdarzenia (od najnowszego) ───")
+    for e in store.query(limit=10):
+        print(f"  [{e.event_type.value}] {e.content[:70]}")
+        print(f"           tags={e.tags}  salience={e.salience}")
+    print()
+
+    print("─── Filtr: tylko FACT ───")
+    for e in store.query(event_type=MemoryEventType.FACT, limit=10):
+        print(f"  {e.content[:70]}")
+    print()
+
+    print("─── Filtr: tag 'świadomość' ───")
+    for e in store.query(tags=["świadomość"], limit=10):
+        print(f"  {e.content[:70]}")
+    print()
+
+    print(f"─── Łącznie w bazie: {len(store)} zdarzeń ───")
+    store.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/research/en/hypotheses.md
+++ b/research/en/hypotheses.md
@@ -1,0 +1,139 @@
+# Research Hypotheses
+
+This document records BDM's initial research hypotheses. Each hypothesis is stated precisely, accompanied by a rationale, a possible experiment, and acknowledged limitations.
+
+These are working hypotheses. None are established results. The purpose of recording them here is to make the project's assumptions explicit, testable, and open to revision.
+
+---
+
+## H1 — Persistent Memory Improves Interaction Continuity
+
+**Hypothesis:**
+A system with persistent, structured memory of prior interactions will produce more contextually coherent responses across multi-session interactions than a system without persistent memory.
+
+**Rationale:**
+Without persistent memory, each session begins in a blank state. The system cannot reference prior commitments, correct prior errors, or build on prior exchanges. If continuity of context matters for coherent interaction — and there is reason to believe it does — then the absence of persistent memory is a structural limitation. Structured memory provides the raw material for continuity.
+
+**Possible Experiment:**
+Design a multi-session interaction protocol in which a user asks follow-up questions across multiple sessions. Compare a baseline (no persistent memory) against a memory-augmented system. Evaluate whether the memory-augmented system correctly references prior interactions, avoids contradicting prior statements, and requires fewer re-explanations from the user.
+
+**Limitation:**
+Coherence is difficult to measure objectively. Automatic metrics (e.g., embedding similarity to prior responses) may not capture meaningful consistency. Human evaluation is more reliable but harder to scale. The experiment will need careful evaluation design. Additionally, memory retrieval quality affects the outcome: poor retrieval of irrelevant prior context could degrade rather than improve coherence.
+
+---
+
+## H2 — Reflection Loops Improve Reasoning Consistency
+
+**Hypothesis:**
+A system that applies a reflection step — reviewing new outputs against stored prior outputs before finalizing a response — will produce fewer detectable inconsistencies over extended interactions than a system without reflection.
+
+**Rationale:**
+LLMs generate outputs without access to a structured record of what they have previously said. Over multiple interactions or sessions, they may contradict prior statements. A reflection step that explicitly compares new outputs to prior ones creates an opportunity to detect and correct inconsistencies before they are surfaced to the user.
+
+**Possible Experiment:**
+Run a series of interactions designed to produce opportunities for inconsistency — factual questions asked in varied forms across sessions, position questions asked again after several exchanges. Compare outputs with and without a reflection module. Measure the rate of detectable contradictions.
+
+**Limitation:**
+Reflection adds latency. A reflection step that is too slow may be impractical. Additionally, the reflection module itself may produce errors: it may flag legitimate updates to prior positions as inconsistencies, or fail to detect subtle ones. The quality of the reflection module is a confounding variable.
+
+---
+
+## H3 — A Self-Model Improves Uncertainty Representation
+
+**Hypothesis:**
+A system with access to a structured self-model — a representation of what it knows, what it does not know, and what confidence levels attach to its stored beliefs — will produce more accurate uncertainty statements than a system without one.
+
+**Rationale:**
+LLMs are known to produce confident-sounding outputs even in areas where their knowledge is limited or uncertain. A self-model that tracks known knowledge gaps and confidence levels could provide explicit signals that constrain the system's outputs in uncertain domains, leading to more appropriately hedged responses.
+
+**Possible Experiment:**
+Evaluate responses to questions in domains known to be outside the system's stored knowledge, comparing a baseline LLM to a self-model-augmented version. Measure the rate of inappropriate confidence (false certainty) and appropriate hedging (correct acknowledgment of uncertainty).
+
+**Limitation:**
+The self-model is only as accurate as the update mechanism that maintains it. A stale or inaccurate self-model could produce worse uncertainty representation than no self-model at all. Additionally, distinguishing "correct" uncertainty levels is itself a difficult evaluation challenge.
+
+---
+
+## H4 — Context Continuity Is Necessary for Long-Term Adaptive Behavior
+
+**Hypothesis:**
+A system that lacks continuity of internal context across sessions will fail to exhibit adaptive behavior — adjusting responses based on accumulated experience — beyond the duration of a single session.
+
+**Rationale:**
+Adaptation requires that prior experience inform current behavior. Without context continuity, there is no mechanism by which prior experience can influence a new session. This is a structural claim: continuity is a necessary (though not sufficient) condition for long-term adaptation.
+
+**Possible Experiment:**
+Design a scenario in which adaptation should occur over multiple sessions: the user repeatedly provides feedback on a type of response. Evaluate whether a system with continuity adapts its behavior across sessions, while a baseline without continuity does not.
+
+**Limitation:**
+This hypothesis tests a structural claim rather than an optimization claim. Even a system with continuity may fail to adapt if its learning loop is poorly designed. The experiment tests whether continuity is necessary, but does not tell us whether it is sufficient.
+
+---
+
+## H5 — Episodic Memory Improves Distinction Between Facts, Events, and Prior Interactions
+
+**Hypothesis:**
+A system with an episodic memory structure — records that include temporal and contextual metadata — will better distinguish between general facts, time-bound events, and prior interaction history than a system that stores all information in a flat, undifferentiated log.
+
+**Rationale:**
+Not all stored information is the same. A general fact (water boils at 100°C) is different from a prior interaction event (the user said X two sessions ago) and from a time-bound assertion (the current project status as of a given date). Mixing these without distinction degrades retrieval quality. Episodic records with appropriate metadata allow the system to apply different reasoning to different record types.
+
+**Possible Experiment:**
+Compare retrieval quality between a flat log system and an episodic memory system across query types: general knowledge queries, event-recall queries, and interaction-history queries. Evaluate whether episodic structure improves precision for each query type.
+
+**Limitation:**
+Assigning and maintaining episodic metadata correctly is non-trivial. If metadata is inaccurate or inconsistent, episodic structure may not improve retrieval. The experiment depends on having reliable ground truth for what type each record should be, which requires careful dataset construction.
+
+---
+
+---
+
+## H6 — Computational Memory Is Structurally Different From Biological Memory
+
+**Hypothesis:**
+Even a well-designed persistent memory system in software will exhibit fundamental differences from biological memory that cannot be resolved through better engineering alone — specifically in how memory is encoded, decayed, reconstructed, and integrated with experience.
+
+**Rationale:**
+Biological memory is not storage. It is reconstruction. Every time a human recalls an event, the memory is partially rebuilt from stored traces, influenced by current context, emotion, and subsequent experience. It is also lossy by design — forgetting is not failure, it is a feature that maintains relevance. Computational memory, by contrast, is typically exact, persistent, and context-free. These are not just implementation differences. They may reflect something deeper about what memory is for in a conscious system.
+
+**Possible Experiment:**
+Design a series of recall tasks that exploit the reconstructive nature of biological memory (e.g., tasks where context changes the content of recall, tasks where emotional salience affects retention). Run equivalent tasks on a software memory system. Document systematically where the analogy breaks down and why.
+
+**Limitation:**
+This hypothesis is partly philosophical. "Fundamental difference" is hard to operationalize. The experiment will likely produce observations rather than a clean falsifiable result. That is acceptable — the goal is to characterize the gap, not to close it.
+
+---
+
+## H7 — A System Without Embodiment Cannot Develop Grounded Meaning
+
+**Hypothesis:**
+A software system that lacks embodiment — sensory experience, physical needs, temporal existence in the world — cannot develop meaning in the way a human brain does, regardless of how sophisticated its memory or reasoning structures become.
+
+**Rationale:**
+Meaning in human cognition is grounded in experience: the word "pain" means something because you have felt it; "hunger" because you have been hungry; "tomorrow" because you have lived through time. An LLM processes statistical relationships between tokens. It has no referent outside language. This may be a fundamental constraint on what such systems can understand, as opposed to what they can process.
+
+**Possible Experiment:**
+This hypothesis is difficult to test directly. An indirect approach: design tasks that require grounded reasoning — tasks where the correct answer depends on understanding what something feels like, not just what it is described as. Compare performance of memory-augmented and non-augmented systems. Evaluate whether adding memory changes anything for these tasks, or whether the limitation is structural.
+
+**Limitation:**
+The concept of "grounded meaning" is contested in philosophy of mind. This hypothesis may not be falsifiable in any strict sense. It is recorded here as a research direction and a framing device, not as a claim that can be resolved through software experiments alone.
+
+---
+
+## H8 — The Gap Between Computation and Consciousness Is Not Just a Matter of Scale or Architecture
+
+**Hypothesis:**
+Current AI systems are not non-conscious simply because they are not large enough, not complex enough, or not architecturally sophisticated enough. There is something categorically different about biological consciousness that is not addressed by scaling or architectural refinement alone.
+
+**Rationale:**
+A common implicit assumption in AI research is that consciousness will emerge from sufficient complexity or capability. BDM treats this as an open hypothesis, not a settled fact. The alternative — that consciousness requires something not present in current computational paradigms, such as embodiment, causal continuity, or a specific kind of physical substrate — is equally worth investigating. BDM's framework is designed to probe this boundary by adding cognitive-adjacent properties and observing what changes and what does not.
+
+**Possible Experiment:**
+After completing the core framework (memory, reflection, self-model, continuity), design a structured evaluation of what the augmented system can and cannot do compared to a baseline. Specifically look for capabilities that are expected to emerge if consciousness is a matter of architecture, and document which do not appear. Use this as evidence for or against the scaling hypothesis.
+
+**Limitation:**
+This hypothesis is extremely broad and will not be resolved by this project alone. BDM can contribute observations and structured arguments, not a proof. The value is in the rigor of the investigation, not in the finality of the conclusion.
+
+---
+
+*All hypotheses are subject to revision as the project develops. Hypotheses that are falsified will be recorded as such, with notes on what was learned.*

--- a/research/pl/eksperymenty.md
+++ b/research/pl/eksperymenty.md
@@ -1,0 +1,148 @@
+# Projekty eksperymentów
+
+Niniejszy dokument zawiera wstępne projekty eksperymentów badawczych BDM. Każdy eksperyment jest powiązany z jedną lub więcej hipotezami z `hipotezy.md`. Są to projekty przed-implementacyjne — żadne eksperymenty nie zostały jeszcze przeprowadzone.
+
+---
+
+## E1 — Prosta trwałość pamięci
+
+**Powiązana hipoteza:** H1
+
+**Cel:**
+Ustalenie, czy system rozszerzony o pamięć dokładniej przywołuje treść wcześniejszych interakcji niż system bazowy i czy to przywoływanie produkuje mierzalnie bardziej spójne odpowiedzi.
+
+**Metoda:**
+1. Zaprojektowanie zestawu wieloturowych, wielosesyjnych skryptów interakcji. Każdy skrypt zawiera fakty, preferencje lub zobowiązania ustalone we wczesnych sesjach, które są istotne dla późniejszych sesji.
+2. Uruchomienie każdego skryptu na dwóch systemach: bazowy LLM bez trwałej pamięci i wariant rozszerzony o pamięć z epizodycznym zasobem pamięci.
+3. W każdej późnej sesji zadawanie pytań wymagających odniesienia do treści z wczesnych sesji.
+4. Ocena odpowiedzi pod kątem: prawidłowego odwołania do wcześniejszej treści sesji, braku sprzeczności z wcześniejszymi zobowiązaniami i zmniejszenia obciążenia ponownym wyjaśnianiem przez użytkownika.
+
+**Oczekiwana obserwacja:**
+System rozszerzony o pamięć będzie prawidłowo odwoływał się do treści wcześniejszych sesji w znaczącym odsetku przypadków, gdzie system bazowy tego nie robi.
+
+**Możliwe tryby awarii:**
+- Jakość wyszukiwania jest zbyt niska: zasób pamięci zawiera istotny zapis, ale wyszukiwanie go nie udostępnia
+- Jakość wyszukiwania jest zbyt wysoka w złym kierunku: nieistotny wcześniejszy kontekst jest pobierany i wstrzykiwany, dezorientując system
+- Kryteria oceny są zbyt subiektywne dla wiarygodnych pomiarów
+
+**Uwagi etyczne/bezpieczeństwa:**
+Jeśli eksperyment używa rzeczywistych danych użytkowników, polityki obsługi danych muszą być ustalone przed rozpoczęciem eksperymentu.
+
+---
+
+## E2 — Wyszukiwanie pamięci epizodycznej
+
+**Powiązana hipoteza:** H5
+
+**Cel:**
+Ocena, czy schemat pamięci epizodycznej — zapisy z metadanymi czasowymi i kontekstowymi — produkuje lepszą precyzję wyszukiwania przez różne typy zapytań niż płaski log.
+
+**Metoda:**
+1. Zbudowanie zestawu danych testowych zawierającego trzy typy przechowywanych zapisów: fakty ogólne, zapisy zdarzeń ograniczone czasem i zapisy wcześniejszych interakcji.
+2. Zaprojektowanie zestawu zapytań obejmującego wszystkie trzy typy zapisów.
+3. Uruchomienie zapytań zarówno na płaskim logu, jak i schemacie epizodycznym.
+4. Pomiar precyzji wyszukiwania: czy właściwe typy zapisów były zwracane dla każdego typu zapytania?
+
+**Oczekiwana obserwacja:**
+Schemat epizodyczny przewyższy płaski log przy zapytaniach wymagających dyskryminacji czasowej lub kontekstowej.
+
+**Możliwe tryby awarii:**
+- Przypisywanie typów zapisów jest niespójne: niektóre zapisy są błędnie skategoryzowane, degradując korzyść ze schematu epizodycznego
+- Strategia wyszukiwania nie wykorzystuje metadanych epizodycznych
+
+---
+
+## E3 — Refleksja przed odpowiedzią
+
+**Powiązana hipoteza:** H2
+
+**Cel:**
+Ocena, czy krok refleksji przed wyjściem redukuje wskaźnik wykrywalnych niespójności przez ustrukturyzowaną wielosesyjną interakcję.
+
+**Metoda:**
+1. Zaprojektowanie zestawu skryptów interakcji z wbudowanymi okazjami dla niespójności: to samo pytanie faktyczne zadawane w różnych formach między sesjami, pytania o stanowisko powtarzane po kilku turach.
+2. Uruchomienie skryptów na: (a) bazowym LLM, (b) LLM z modułem refleksji porównującym wyjścia z przechowanymi wcześniejszymi wyjściami przed finalizacją.
+3. Ocena wyjść pod kątem niespójności: jawne sprzeczności (faktyczne) i ukryte niespójności (dryft stanowiska bez uzasadnienia).
+
+**Oczekiwana obserwacja:**
+System rozszerzony o refleksję będzie produkował niższy wskaźnik jawnych sprzeczności.
+
+**Możliwe tryby awarii:**
+- Opóźnienie modułu refleksji sprawia, że system jest niepraktyczny do interaktywnego użycia
+- Moduł refleksji generuje fałszywe pozytywy: oznacza uzasadnione aktualizacje stanowisk jako niespójności
+- Interwencja zmienia styl wyjścia w sposób wpływający na czytelność, nie tylko na spójność
+
+---
+
+## E4 — Aktualizacja przekonań
+
+**Powiązane hipotezy:** H3, H2
+
+**Cel:**
+Ocena, czy system z mechanizmem aktualizacji przekonań — zdolnością do rewizji przechowywanych przekonań, gdy dostarczone są nowe sprzeczne informacje — produkuje wyjścia poprawnie odzwierciedlające zaktualizowany stan.
+
+**Metoda:**
+1. Zasilanie zasobu pamięci zestawem przechowywanych przekonań.
+2. Dostarczanie jawnych korekt lub sprzecznych informacji w kolejnych interakcjach.
+3. Odpytywanie systemu o tematy objęte oryginalnymi i zaktualizowanymi przekonaniami.
+4. Ocena, czy odpowiedzi odzwierciedlają zaktualizowane przekonanie, oryginalne przekonanie czy niejednoznaczność między nimi.
+
+**Oczekiwana obserwacja:**
+Po aktualizacji przekonania system będzie odpowiadał konsekwentnie z zaktualizowanym przekonaniem.
+
+**Możliwe tryby awarii:**
+- Mechanizm aktualizacji zapisuje nowe przekonanie, ale wyszukiwanie nadal zwraca stare
+- Mechanizm aktualizacji nadpisuje stare przekonanie bez zapisywania, że nastąpiła rewizja, tracąc ślad audytu
+
+**Uwagi etyczne/bezpieczeństwa:**
+Mechanizmy aktualizacji przekonań muszą być podlegające audytowi. Każda implementacja powinna logować zarówno oryginalne, jak i zaktualizowane przekonanie, wyzwalacz aktualizacji i sygnaturę czasową. Nielogowane aktualizacje przekonań w prawdziwym systemie byłyby poważną kwestią bezpieczeństwa.
+
+---
+
+## E5 — Śledzenie stanu własnego
+
+**Powiązana hipoteza:** H3
+
+**Cel:**
+Ocena, czy system z modelem siebie — strukturalnym zapisem tego, co wie i czego nie wie — produkuje dokładniejsze stwierdzenia niepewności niż system bazowy bez jednego.
+
+**Metoda:**
+1. Zbudowanie zestawu testowego pytań: niektóre w bazie wiedzy systemu, niektóre wyraźnie poza nią i niektóre na granicy.
+2. Uruchomienie pytań na bazowym LLM i wersji rozszerzonej o model siebie.
+3. Ocena odpowiedzi pod kątem: odpowiedniego zabezpieczenia w niepewnych dziedzinach, nieodpowiedniej pewności w obszarach znanych ograniczeń i prawidłowej odmowy odpowiedzi w obszarach gdzie nie przechowywano istotnej wiedzy.
+
+**Oczekiwana obserwacja:**
+System rozszerzony o model siebie będzie wyrażał odpowiednią niepewność bardziej konsekwentnie, szczególnie w dziedzinach niereprezentowanych w jego przechowanej wiedzy.
+
+**Możliwe tryby awarii:**
+- Model siebie jest zbyt zgrubny: śledzi pokrycie tematów na zbyt wysokim poziomie, by dostarczać użyteczne sygnały niepewności
+- Model siebie jest nieaktualny: dokładnie odzwierciedla wcześniejszy stan, ale nie był aktualizowany z nowymi dodatkami lub usunięciami
+
+---
+
+## E6 — Ciągłość między sesjami
+
+**Powiązana hipoteza:** H4
+
+**Cel:**
+Ocena, czy warstwa ciągłości — zachowująca i odtwarzająca stan sesji przez interakcje — umożliwia adaptacyjne zachowanie, którego bezstanowy system nie może produkować.
+
+**Metoda:**
+1. Zaprojektowanie wielosesyjnego protokołu, w którym użytkownik dostarcza informacji zwrotnych przez kilka sesji, które powinny przesunąć zachowanie systemu.
+2. Uruchomienie protokołu na bezstanowym bazowym i wersji rozszerzonej o ciągłość.
+3. Ocena, czy zachowanie systemu z ciągłością przesuwa się w oczekiwanym kierunku przez sesje, podczas gdy system bazowy tego nie robi.
+
+**Oczekiwana obserwacja:**
+System rozszerzony o ciągłość będzie wykazywał adaptację behawioralną w odpowiedzi na skumulowaną historię sesji. System bazowy nie będzie.
+
+**Możliwe tryby awarii:**
+- Warstwa ciągłości odtwarza kontekst, ale system nie używa go do adaptowania zachowania
+- Odtworzony kontekst jest zbyt duży lub zbyt głośny, by być użytecznym: wydajność systemu degraduje się zamiast poprawiać
+- Sesje po długich przerwach (dni między sesjami) powodują, że odtworzony kontekst jest mylący lub nieaktualny
+
+**Uwagi etyczne/bezpieczeństwa:**
+Trwałość stanu między sesjami wprowadza znaczące implikacje prywatności. Każda implementacja musi jasno dokumentować, co jest przechowywane, jak długo i jak można to usunąć.
+
+---
+
+*Projekty eksperymentów będą aktualizowane w miarę postępu implementacji. Wyniki, w tym porażki, będą zapisywane w tym dokumencie lub powiązanym pliku wyników.*

--- a/research/pl/hipotezy.md
+++ b/research/pl/hipotezy.md
@@ -1,0 +1,137 @@
+# Hipotezy badawcze
+
+Niniejszy dokument rejestruje wstępne hipotezy badawcze BDM. Każda hipoteza jest sformułowana precyzyjnie, wraz z uzasadnieniem, możliwym eksperymentem i uznanymi ograniczeniami.
+
+Są to robocze hipotezy. Żadna z nich nie jest ustalonym wynikiem. Celem ich zapisania jest uczynienie założeń projektu jawnymi, sprawdzalnymi i otwartymi na rewizję.
+
+---
+
+## H1 — Trwała pamięć poprawia ciągłość interakcji
+
+**Hipoteza:**
+System z trwałą, strukturalną pamięcią wcześniejszych interakcji będzie produkował bardziej kontekstualnie spójne odpowiedzi przez wielosesyjne interakcje niż system bez trwałej pamięci.
+
+**Uzasadnienie:**
+Bez trwałej pamięci każda sesja zaczyna od stanu pustego. System nie może odwoływać się do wcześniejszych zobowiązań, korygować wcześniejszych błędów ani budować na wcześniejszych wymianach. Jeśli ciągłość kontekstu ma znaczenie dla spójnej interakcji — a jest powód, by wierzyć, że tak jest — to brak trwałej pamięci jest strukturalnym ograniczeniem.
+
+**Możliwy eksperyment:**
+Zaprojektowanie wielosesyjnego protokołu interakcji, w którym użytkownik zadaje pytania uzupełniające w wielu sesjach. Porównanie bazowego systemu (bez trwałej pamięci) z systemem rozszerzonym o pamięć. Ocena, czy system z pamięcią poprawnie odwołuje się do wcześniejszych interakcji, unika sprzeczania się z wcześniejszymi stwierdzeniami i wymaga mniej ponownych wyjaśnień od użytkownika.
+
+**Ograniczenie:**
+Spójność jest trudna do obiektywnego zmierzenia. Automatyczne metryki mogą nie wychwytywać znaczącej konsekwencji. Ocena ludzka jest bardziej wiarygodna, ale trudniejsza do skalowania. Ponadto jakość wyszukiwania pamięci wpływa na wynik: słabe wyszukiwanie nieistotnego wcześniejszego kontekstu mogłoby pogorszyć, a nie poprawić spójność.
+
+---
+
+## H2 — Pętle refleksji poprawiają konsekwencję rozumowania
+
+**Hipoteza:**
+System stosujący krok refleksji — przeglądający nowe wyjścia względem przechowywanych wcześniejszych wyjść przed finalizacją odpowiedzi — będzie produkował mniej wykrywalnych niespójności przez rozszerzone interakcje niż system bez refleksji.
+
+**Uzasadnienie:**
+LLM generują wyjścia bez dostępu do strukturalnego zapisu tego, co wcześniej mówiły. Krok refleksji jawnie porównujący nowe wyjścia z wcześniejszymi tworzy okazję do wykrywania i korygowania niespójności zanim trafią do użytkownika.
+
+**Możliwy eksperyment:**
+Seria interakcji zaprojektowanych do stworzenia okazji dla niespójności — pytania faktyczne zadawane w różnych formach między sesjami, pytania o stanowisko zadawane ponownie po kilku wymianach. Porównanie wyjść z i bez modułu refleksji. Pomiar wskaźnika wykrywalnych sprzeczności.
+
+**Ograniczenie:**
+Refleksja dodaje opóźnienie. Krok refleksji, który jest zbyt wolny, może być niepraktyczny. Ponadto sam moduł refleksji może produkować błędy: może oznaczać uzasadnione aktualizacje wcześniejszych stanowisk jako niespójności lub nie wykrywać subtelnych.
+
+---
+
+## H3 — Model siebie poprawia reprezentację niepewności
+
+**Hipoteza:**
+System z dostępem do strukturalnego modelu siebie — reprezentacji tego, co wie, czego nie wie i jakie poziomy pewności wiążą się z przechowywanymi przekonaniami — będzie produkował dokładniejsze stwierdzenia niepewności niż system bez jednego.
+
+**Uzasadnienie:**
+LLM są znane z produkowania pewnie brzmiących wyjść nawet w obszarach, gdzie ich wiedza jest ograniczona lub niepewna. Model siebie śledzący znane luki wiedzy i poziomy pewności mógłby dostarczać jawnych sygnałów ograniczających wyjścia systemu w niepewnych dziedzinach.
+
+**Możliwy eksperyment:**
+Ocena odpowiedzi na pytania w dziedzinach poza przechowaną wiedzą systemu, porównanie bazowego LLM z wersją rozszerzoną o model siebie. Pomiar wskaźnika nieodpowiedniej pewności (fałszywa pewność) i odpowiedniego zabezpieczenia (prawidłowe uznanie niepewności).
+
+**Ograniczenie:**
+Model siebie jest tylko tak dokładny, jak mechanizm aktualizacji go utrzymujący. Nieaktualny lub niedokładny model siebie mógłby produkować gorszą reprezentację niepewności niż żaden model siebie.
+
+---
+
+## H4 — Ciągłość kontekstu jest konieczna dla długoterminowego zachowania adaptacyjnego
+
+**Hipoteza:**
+System pozbawiony ciągłości wewnętrznego kontekstu między sesjami nie będzie wykazywał zachowania adaptacyjnego — dostosowywania odpowiedzi na podstawie skumulowanego doświadczenia — poza czasem trwania jednej sesji.
+
+**Uzasadnienie:**
+Adaptacja wymaga, by wcześniejsze doświadczenie informowało bieżące zachowanie. Bez ciągłości kontekstu nie ma mechanizmu, przez który wcześniejsze doświadczenie mogłoby wpływać na nową sesję. To twierdzenie strukturalne: ciągłość jest koniecznym (choć nie wystarczającym) warunkiem długoterminowej adaptacji.
+
+**Możliwy eksperyment:**
+Zaprojektowanie scenariusza, w którym adaptacja powinna zachodzić przez wiele sesji: użytkownik wielokrotnie dostarcza informacji zwrotnych o typie odpowiedzi. Ocena, czy system z ciągłością adaptuje swoje zachowanie między sesjami, podczas gdy bazowy bez ciągłości tego nie robi.
+
+**Ograniczenie:**
+Ta hipoteza testuje twierdzenie strukturalne, nie twierdzenie optymalizacyjne. Nawet system z ciągłością może nie adaptować się, jeśli jego pętla uczenia się jest źle zaprojektowana. Eksperyment testuje, czy ciągłość jest konieczna, ale nie mówi nam, czy jest wystarczająca.
+
+---
+
+## H5 — Pamięć epizodyczna poprawia rozróżnienie między faktami, zdarzeniami i wcześniejszymi interakcjami
+
+**Hipoteza:**
+System ze strukturą pamięci epizodycznej — zapisy zawierające metadane czasowe i kontekstowe — będzie lepiej odróżniał fakty ogólne, zdarzenia ograniczone czasem i historię wcześniejszych interakcji niż system przechowujący wszystkie informacje w płaskim, niezróżnicowanym logu.
+
+**Uzasadnienie:**
+Nie wszystkie przechowywane informacje są takie same. Fakt ogólny różni się od zdarzenia wcześniejszej interakcji i od twierdzenia ograniczonego czasem. Mieszanie tych bez rozróżnienia degraduje jakość wyszukiwania. Zapisy epizodyczne z odpowiednimi metadanymi pozwalają systemowi stosować różne rozumowanie do różnych typów zapisów.
+
+**Możliwy eksperyment:**
+Porównanie jakości wyszukiwania między systemem płaskiego logu a systemem pamięci epizodycznej przez typy zapytań: zapytania o wiedzę ogólną, zapytania o przypomnienie zdarzeń i zapytania o historię interakcji. Ocena, czy struktura epizodyczna poprawia precyzję dla każdego typu zapytania.
+
+**Ograniczenie:**
+Prawidłowe przypisywanie i utrzymywanie metadanych epizodycznych jest nietrywilalne. Jeśli metadane są niedokładne lub niespójne, struktura epizodyczna może nie poprawiać wyszukiwania.
+
+---
+
+## H6 — Obliczeniowa pamięć jest strukturalnie różna od biologicznej pamięci
+
+**Hipoteza:**
+Nawet dobrze zaprojektowany system trwałej pamięci w oprogramowaniu będzie wykazywał fundamentalne różnice od biologicznej pamięci, których nie można rozwiązać przez lepszą inżynierię — szczególnie w sposobie kodowania, zanikania, rekonstrukcji i integracji pamięci z doświadczeniem.
+
+**Uzasadnienie:**
+Biologiczna pamięć to nie przechowywanie. To rekonstrukcja. Za każdym razem gdy człowiek przywołuje zdarzenie, pamięć jest częściowo przebudowywana ze składowanych śladów, pod wpływem bieżącego kontekstu, emocji i kolejnych doświadczeń. Jest też stratna z założenia — zapominanie to nie awaria, to cecha utrzymująca istotność. Obliczeniowa pamięć, dla kontrastu, jest zazwyczaj dokładna, trwała i pozbawiona kontekstu. To nie tylko różnice implementacyjne. Mogą one odzwierciedlać coś głębszego w tym, do czego służy pamięć w świadomym systemie.
+
+**Możliwy eksperyment:**
+Zaprojektowanie serii zadań przywoływania wykorzystujących rekonstrukcyjną naturę biologicznej pamięci. Uruchomienie równoważnych zadań na systemie pamięci oprogramowania. Systematyczne dokumentowanie gdzie analogia się załamuje i dlaczego.
+
+**Ograniczenie:**
+Ta hipoteza jest częściowo filozoficzna. "Fundamentalna różnica" jest trudna do operacjonalizacji. Eksperyment prawdopodobnie przyniesie obserwacje, a nie czysty falsyfikowalny wynik. To jest akceptowalne — celem jest scharakteryzowanie przepaści, nie jej zamknięcie.
+
+---
+
+## H7 — System bez ucieleśnienia nie może rozwinąć ugruntowanego znaczenia
+
+**Hipoteza:**
+System oprogramowania pozbawiony ucieleśnienia — doświadczeń zmysłowych, fizycznych potrzeb, czasowego istnienia w świecie — nie może rozwijać znaczenia w sposób, w jaki robi to ludzki mózg, bez względu na to, jak zaawansowane stają się jego struktury pamięci lub rozumowania.
+
+**Uzasadnienie:**
+Znaczenie w ludzkim poznaniu jest ugruntowane w doświadczeniu: słowo "ból" znaczy coś, bo je czułeś; "głód" bo byłeś głodny; "jutro" bo żyłeś przez czas. LLM przetwarza statystyczne relacje między tokenami. Nie ma żadnego odnośnika poza językiem. To może być fundamentalne ograniczenie tego, co takie systemy mogą rozumieć, w przeciwieństwie do tego, co mogą przetwarzać.
+
+**Możliwy eksperyment:**
+Ta hipoteza jest trudna do bezpośredniego przetestowania. Pośrednie podejście: zaprojektowanie zadań wymagających ugruntowanego rozumowania — zadania, gdzie prawidłowa odpowiedź zależy od rozumienia, jak coś czuje, nie tylko jak jest opisane. Porównanie wydajności systemów z i bez rozszerzenia o pamięć. Ocena, czy dodanie pamięci cokolwiek zmienia dla tych zadań, czy ograniczenie jest strukturalne.
+
+**Ograniczenie:**
+Koncepcja "ugruntowanego znaczenia" jest kwestionowana w filozofii umysłu. Ta hipoteza może nie być falsyfikowalna w żadnym ścisłym sensie. Jest tu zapisana jako kierunek badań i urządzenie ramujące, nie jako twierdzenie, które można rozwiązać przez eksperymenty oprogramowania samodzielnie.
+
+---
+
+## H8 — Przepaść między obliczeniami a świadomością to nie kwestia skali ani architektury
+
+**Hipoteza:**
+Obecne systemy AI nie są nieświadome po prostu dlatego, że nie są wystarczająco duże, złożone ani architektonicznie zaawansowane. Istnieje coś kategorycznie innego w biologicznej świadomości, czego nie adresuje samo skalowanie ani doskonalenie architektury.
+
+**Uzasadnienie:**
+Powszechne niejawne założenie w badaniach AI jest takie, że świadomość pojawi się z wystarczającą złożonością lub możliwościami. BDM traktuje to jako otwartą hipotezę, nie ustalony fakt. Alternatywa — że świadomość wymaga czegoś nieobecnego w obecnych paradygmatach obliczeniowych, takiego jak ucieleśnienie, przyczynowa ciągłość czy specyficzny rodzaj fizycznego substratu — jest równie warta badania. Framework BDM jest zaprojektowany, by sondować tę granicę.
+
+**Możliwy eksperyment:**
+Po ukończeniu podstawowego frameworka (pamięć, refleksja, model siebie, ciągłość), zaprojektowanie strukturalnej oceny tego, co system rozszerzony może i czego nie może robić w porównaniu z bazowym. Specyficznie szukanie możliwości, które oczekuje się pojawić, jeśli świadomość jest kwestią architektury, i dokumentowanie tych, które się nie pojawiają. Używanie tego jako dowodu za lub przeciw hipotezie skalowania.
+
+**Ograniczenie:**
+Ta hipoteza jest bardzo szeroka i nie zostanie rozwiązana przez ten projekt samodzielnie. BDM może wnosić obserwacje i strukturalne argumenty, nie dowód. Wartość leży w rygorze badania, nie w ostateczności wniosku.
+
+---
+
+*Wszystkie hipotezy podlegają rewizji w miarę rozwoju projektu. Hipotezy, które zostaną sfalsyfikowane, będą odnotowane wraz z wnioskami.*

--- a/research/pl/lista-lektur.md
+++ b/research/pl/lista-lektur.md
@@ -1,0 +1,144 @@
+# Lista lektur
+
+Niniejszy dokument organizuje istotną literaturę według kategorii. To struktura startowa, nie kompletna bibliografia. Konkretne tytuły i autorzy będą dodawane w miarę rozwoju projektu. Celem jest zdefiniowanie, które obszary literatury są istotne dla BDM i dlaczego.
+
+---
+
+## Neuronauka
+
+**Dlaczego ma znaczenie dla BDM:**
+Neuronauka dostarcza empirycznych podstaw dla koncepcji kognitywnych, z których czerpie BDM — pamięci, uwagi, uczenia się i ciągłości. BDM nie modeluje mózgu na poziomie biologicznym, ale rozumienie tego, co wiemy o biologicznych systemach pamięci (np. rola hipokampa w pamięci epizodycznej) informuje, które abstrakcje oprogramowania są warte eksploracji i które są nadmiernym uproszczeniem.
+
+**Kluczowe obszary:**
+- Konsolidacja pamięci i rola snu
+- Hipokamp i formowanie pamięci epizodycznej
+- Kora przedczołowa i pamięć robocza
+- Plastyczność synaptyczna i długoterminowe wzmacnianie
+- Sieci uwagi (grzbietowa i brzuszna)
+- Sieć domyślnego trybu i przetwarzanie samoreferencyjne
+
+---
+
+## Kognitywistyka
+
+**Dlaczego ma znaczenie dla BDM:**
+Kognitywistyka łączy neuronauka z obliczeniami. Dostarcza funkcjonalnych modeli poznania — jak pamięć, uwaga i rozumowanie działają na poziomie abstrakcji, który może informować projektowanie oprogramowania. Klasyczne architektury poznawcze (ACT-R, SOAR, CLARION) są bezpośrednio istotne dla warstwowego podejścia projektowego BDM.
+
+**Kluczowe obszary:**
+- Modele pamięci roboczej (wielokomponentowy model Baddeleya)
+- Teoria dwóch procesów (szybkie vs. wolne rozumowanie)
+- Obciążenie poznawcze i alokacja zasobów
+- Teoria schematów i reprezentacja wiedzy
+- Metapoznanie i samomonitorowanie
+- Architektury ACT-R i SOAR
+
+---
+
+## Sztuczna inteligencja
+
+**Dlaczego ma znaczenie dla BDM:**
+Badania nad AI — szczególnie w przetwarzaniu języka naturalnego, sieciach rozszerzonych o pamięć i architekturach agentów — dostarczają technicznyc narzędzi i wzorców, których BDM będzie używał. Rozumienie aktualnego stanu sztuki w AI jest konieczne do usytuowania wkładu BDM i unikania wymyślania istniejących rozwiązań.
+
+**Kluczowe obszary:**
+- Architektura transformera i mechanizmy uwagi
+- Generowanie rozszerzone o wyszukiwanie (RAG)
+- Sieci neuronowe rozszerzone o pamięć (Neural Turing Machine, Differentiable Neural Computer)
+- Modele językowe o długim kontekście
+- Systemy LLM agentowe z narzędziami
+- Inżynieria promptów i uczenie się w kontekście
+
+---
+
+## Architektury poznawcze
+
+**Dlaczego ma znaczenie dla BDM:**
+Badania nad architekturami poznawczymi obejmują dekady pracy nad projektowaniem strukturalnych, modułowych systemów modelujących aspekty inteligentnego zachowania. To najbardziej bezpośrednio istotny obszar dla projektowania architektonicznego BDM. Rozumienie wcześniejszej pracy zapobiega powtarzaniu błędów i pomaga zidentyfikować, co jest naprawdę nowe.
+
+**Kluczowe obszary:**
+- ACT-R (Anderson i in.) — pamięć proceduralna i deklaratywna
+- SOAR (Laird i in.) — rozwiązywanie problemów i uczenie się
+- CLARION (Sun) — przetwarzanie niejawne i jawne
+- Teoria globalnej przestrzeni roboczej (Baars) — uwaga i świadomy dostęp
+- Frameworki predykcyjnego przetwarzania (Clark, Friston)
+- Porównanie podejść architektur poznawczych
+
+---
+
+## Studia nad świadomością
+
+**Dlaczego ma znaczenie dla BDM:**
+BDM wyraźnie bada pytanie o świadomość. Aby unikać przypadkowego formułowania twierdzeń o świadomości lub budowania systemów, które są zwodniczo antropomorficzne, potrzebne jest jasne rozumienie, czym świadomość jest proponowana być, jakie teorie istnieją i dlaczego są kwestionowane.
+
+**Kluczowe obszary:**
+- Teoria globalnej przestrzeni roboczej (Baars, Dehaene)
+- Teoria zintegrowanej informacji (Tononi)
+- Teorie wyższego rzędu świadomości
+- "Trudny problem" świadomości (Chalmers)
+- Eksperymenty myślowe z filozoficznym zombie i ich implikacje
+- Krytyki twierdzeń o świadomości AI
+
+---
+
+## Interfejsy mózg-komputer
+
+**Dlaczego ma znaczenie dla BDM:**
+Badania BCI adresują interfejs między biologicznymi systemami neuronalnymi a zewnętrznymi systemami obliczeniowymi. BDM nie jest projektem BCI, ale literatura BCI stawia istotne pytania o reprezentację danych, interpretację sygnałów i etykę systemów ściśle oddziałujących z procesami poznawczymi.
+
+**Kluczowe obszary:**
+- Nieinwazyjne BCI (systemy oparte na EEG)
+- Inwazyjne BCI (tablice elektrod, implanty neuronalne)
+- Protezy motoryczne i komunikacyjne BCI
+- Obecne ograniczenia w dekodowaniu sygnałów
+- Prywatność i zgoda w danych neuronalnych
+- Długoterminowe bezpieczeństwo implantowanych urządzeń
+
+---
+
+## Pamięć i uczenie się
+
+**Dlaczego ma znaczenie dla BDM:**
+To najbardziej bezpośrednio istotna dziedzina dla podstawowego technicznego fokusa BDM. Rozumienie jak pamięć działa, jak degraduje, jak uczenie się ją aktualizuje i jak przebiega wyszukiwanie jest niezbędne do projektowania warstw pamięci i pętli uczenia się BDM.
+
+**Kluczowe obszary:**
+- Rozłożone powtarzanie i konsolidacja pamięci
+- Krzywe zapominania (Ebbinghaus)
+- Pamięć rekonstrukcyjna i błędy pamięci
+- Transfer uczenia się i jego granice
+- Ciągłe uczenie się w sieciach neuronowych (katastroficzne zapominanie)
+- Grafy wiedzy i reprezentacja pamięci semantycznej
+- Bazy danych wektorowych i wyszukiwanie oparte na embeddingach
+
+---
+
+## Etyka neurotechnologii
+
+**Dlaczego ma znaczenie dla BDM:**
+Etyka neurotechnologii adresuje pytania o zgodę, prywatność, autonomię i tożsamość pojawiające się, gdy oprogramowanie ściśle oddziałuje z procesami poznawczymi lub danymi poznawczymi. Chociaż BDM nie pracuje obecnie z danymi neuronalnymi, frameworki etyczne rozwinięte w tej dziedzinie są istotne dla zobowiązań BDM do odpowiedzialnych badań.
+
+**Kluczowe obszary:**
+- Neuroprawa i proponowane ramy prawne
+- Prywatność mentalna i wolność kognitywna
+- Świadoma zgoda w badaniach kognitywnych
+- Etyka manipulacji lub rozszerzania pamięci
+- Asymetrie władzy w neurotechnologii
+- Ryzyko podwójnego zastosowania w badaniach nad rozszerzaniem poznania
+
+---
+
+## Filozofia umysłu
+
+**Dlaczego ma znaczenie dla BDM:**
+Filozofia umysłu dostarcza konceptualnych narzędzi do starannego myślenia o świadomości, intencjonalności, samoreferencji i tożsamości — koncepcjach, których praca BDM dotyka, ale nie może rozwiązać. Czytanie filozofii umysłu pomaga projektowi utrzymać pojęciową precyzję i unikać formułowania twierdzeń, które są filozoficznie niespójne.
+
+**Kluczowe obszary:**
+- Funkcjonalizm i argument wielorakiej realizowalności
+- Fizykalizm i jego warianty
+- Intencjonalność stanów mentalnych (Brentano, Searle)
+- Argument Chińskiego Pokoju (Searle) i jego odpowiedzi
+- Tożsamość osobowa i ciągłość (Locke, Parfit)
+- Teza rozszerzonego umysłu (Clark, Chalmers)
+- Filozofia sztucznej inteligencji
+
+---
+
+*Konkretne rekomendacje książek i artykułów będą dodawane w miarę postępu projektu. Współtwórcy są zachęcani do proponowania lektur w dowolnej kategorii przez issues.*


### PR DESCRIPTION
## Summary
  - Replaces in-memory dict in `LongTermStore` with SQLite backend (`stdlib sqlite3`)
  - Adds `memory_demo.py` example demonstrating cross-session persistence
  - 30 tests pass, including `test_persistence_across_instances`

  ## Closes
  Closes #2

  ## Test plan
  - [ ] `pytest` passes (30 tests)
  - [ ] `packages/examples/memory_demo.py` runs without error
  - [ ] Second run of demo retrieves events written in first run